### PR TITLE
Ruby 2 5 compatibility and alias command for list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.2 - Alpha 3] - Unreleased
+
+### UX/UI
+- Add `wehereami` as an alias for `list` command
+
+### Bug fixes
+- Backward compatible issue: Array#filter is available in ruby 2.5.x and above.
+
+
 ## [0.2.1 - Alpha 3] - Render mechanism and theme system
 ### UX/UI
 - New color scheme: 256, as the default color scheme. It works well with all 256-color terminal emulators.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ An interactive Repl for you to interact with your program, inspect values, updat
 
 **Key binding:** F5
 
-**Alias**: `l`
+**Alias**: `l`, `whereami`
 
 Refresh the whole terminal UI. This command doesn't move you to other steps, nor change any data in your session. It is useful (or the only way) to get back the beautiful UI if you type too much in the REPL console.
 

--- a/lib/ruby_jard/commands/list_command.rb
+++ b/lib/ruby_jard/commands/list_command.rb
@@ -27,3 +27,4 @@ end
 
 Pry::Commands.add_command(RubyJard::Commands::ListCommand)
 Pry::Commands.alias_command 'l', 'list'
+Pry::Commands.alias_command 'whereami', 'list'

--- a/lib/ruby_jard/decorators/path_decorator.rb
+++ b/lib/ruby_jard/decorators/path_decorator.rb
@@ -20,7 +20,7 @@ module RubyJard
       def initialize(path, lineno)
         @gem = nil
         @gem_version = nil
-        @path = path
+        @path = path.to_s
         @lineno = lineno
         @type = TYPE_UNKNOWN
 

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -38,7 +38,6 @@ module RubyJard
     PRY_EXCLUDED_COMMANDS = [
       'pry-backtrace', # Redundant method for normal user
       'watch',         # Conflict with byebug and jard watch
-      'whereami',      # Jard already provides similar. Keeping this command makes conflicted experience
       'edit',          # Sorry, but a file should not be editted while debugging, as it made breakpoints shifted
       'play',          # What if the played files or methods include jard again?
       'stat',          # Included in jard UI

--- a/lib/ruby_jard/screens/threads_screen.rb
+++ b/lib/ruby_jard/screens/threads_screen.rb
@@ -8,7 +8,7 @@ module RubyJard
       end
 
       def build
-        contexts = RubyJard.current_session.contexts.filter { |c| c.thread.alive? }
+        contexts = RubyJard.current_session.contexts.select { |c| c.thread.alive? }
         contexts = sort_contexts(contexts)
         @rows = contexts.map do |context|
           RubyJard::Row.new(

--- a/lib/ruby_jard/version.rb
+++ b/lib/ruby_jard/version.rb
@@ -2,5 +2,5 @@
 
 # Semantic versionn
 module RubyJard
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
### UX/UI
- Add `wehereami` as an alias for `list` command

### Bug fixes
- Backward compatible issue: Array#filter is available in ruby 2.5.x and above.