### PR TITLE
Fix skipped next

### DIFF
--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -72,7 +72,8 @@ module RubyJard
       RubyJard::Console.clear_screen(@output)
 
       def $stdout.write(string)
-        if !RubyJard::ScreenManager.updating? && RubyJard::ScreenManager.started?
+        # NOTE: `RubyJard::ScreenManager.instance` is a must. Jard doesn't work well with delegator
+        if !RubyJard::ScreenManager.instance.updating? && RubyJard::ScreenManager.instance.started?
           RubyJard::ScreenManager.instance.output_storage.write(string)
         end
         super

--- a/lib/ruby_jard/screens/backtrace_screen.rb
+++ b/lib/ruby_jard/screens/backtrace_screen.rb
@@ -62,7 +62,7 @@ module RubyJard
             end
           elsif klass.singleton_class?
             # No easy way to get the original class of a singleton class
-            object.name
+            object.respond_to?(:name) ? object.name : object.to_s
           else
             klass.name
           end


### PR DESCRIPTION
### Scenario

```ruby
    a = "Hello" * 20

    jard
    puts "Hello"
    puts "WTF is going on?"

    b = 1..20
```

### Explanation
Internally, Ruby Jard overrides STDOUT#write method to append all the output to a buffer, and print it out after the program exits.

```ruby
      def $stdout.write(string)
        # NOTE: `RubyJard::ScreenManager.instance` is a must. Jard doesn't work well with delegator
        if !RubyJard::ScreenManager.instance.updating? && RubyJard::ScreenManager.instance.started?
          RubyJard::ScreenManager.instance.output_storage.write(string)
        end
        super
      end
```

In the source code:

```ruby
    class << self
      extend Forwardable

      def_delegators :instance, :update, :draw_error, :started?, :updating?

      def instance
        @instance ||= new
      end
    end
```

It turns out  Byebug doesn't work well with delegators. Fixing the root cause is not easy. I'll work with byebug later.