### PR TITLE
Broken repl suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 ### Bug fixes
 - Jard doesn't work when place at the end of a method, or a block.
 - box title overflow
-- source screen doesn't work well with anonymous evaluation, or `ruby -e`
+- Source screen doesn't work well with anonymous evaluation, or `ruby -e`
+- Auto-completion of pry (actually readline) is broken
 
 ### Internal & Refactoring
 - Add tests for critical sections
+- Use PTY to feed output from pry to actual STDOUT
 
 ## [0.2.2 - Alpha 3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - box title overflow
 - Source screen doesn't work well with anonymous evaluation, or `ruby -e`
 - Auto-completion of pry (actually readline) is broken
+- Could not exit when starting Jard inside irb
 
 ### Internal & Refactoring
 - Add tests for critical sections

--- a/lib/ruby_jard/commands/exit_command.rb
+++ b/lib/ruby_jard/commands/exit_command.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RubyJard
+  module Commands
+    # Command used to exit program execution.
+    class ExitCommand < Pry::ClassCommand
+      group 'RubyJard'
+      description 'Exit program execution.'
+
+      match 'exit'
+
+      banner <<-BANNER
+      Usage: exit
+      Examples:
+        exit
+
+      Exit program execution. The program will stop at the next breakpoint, or run until it finishes.
+      BANNER
+
+      def process
+        RubyJard::ControlFlow.dispatch(:exit)
+      end
+    end
+  end
+end
+
+Pry::Commands.add_command(RubyJard::Commands::ExitCommand)

--- a/lib/ruby_jard/console.rb
+++ b/lib/ruby_jard/console.rb
@@ -72,7 +72,6 @@ module RubyJard
         return input.getch(min: 0, time: timeout) if input.respond_to?(:getch)
 
         raw!
-        disable_echo!
         key =
           begin
             input.read_nonblock(255)
@@ -90,7 +89,6 @@ module RubyJard
         key
       ensure
         cooked!
-        enable_echo!
       end
 
       def raw!(output = STDOUT)

--- a/lib/ruby_jard/control_flow.rb
+++ b/lib/ruby_jard/control_flow.rb
@@ -7,7 +7,8 @@ module RubyJard
   class ControlFlow
     THROW_KEYWORD = :jard_control_flow
     ALLOW_LIST = {
-      continue: [:times],           # lib/ruby_jard/commands/continue_command.rb
+      continue: [],                 # lib/ruby_jard/commands/continue_command.rb
+      exit: [],                     # lib/ruby_jard/commands/exit_command.rb
       frame: [:frame],              # lib/ruby_jard/commands/frame_command.rb
       up: [:times],                 # lib/ruby_jard/commands/up_command.rb
       down: [:times],               # lib/ruby_jard/commands/down_command.rb

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+require 'ruby_jard/commands/validation_helpers'
+require 'ruby_jard/commands/continue_command'
+require 'ruby_jard/commands/exit_command'
+require 'ruby_jard/commands/up_command'
+require 'ruby_jard/commands/down_command'
+require 'ruby_jard/commands/next_command'
+require 'ruby_jard/commands/step_command'
+require 'ruby_jard/commands/step_out_command'
+require 'ruby_jard/commands/frame_command'
+require 'ruby_jard/commands/list_command'
+require 'ruby_jard/commands/color_scheme_command'
+
 module RubyJard
   ##
   # Byebug allows customizing processor with a series of hooks (https://github.com/deivid-rodriguez/byebug/blob/e1fb8209d56922f7bafd128af84e61568b6cd6a7/lib/byebug/processors/command_processor.rb)
@@ -113,6 +125,10 @@ module RubyJard
 
     def handle_continue_command(_options = {})
       # Do nothing
+    end
+
+    def handle_exit_command(_options = {})
+      Kernel.exit
     end
 
     def handle_key_binding_command(options = {})

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -88,6 +88,7 @@ module RubyJard
     def repl(current_binding)
       RubyJard::Console.disable_echo!
 
+      STDOUT.flush
       Readline.input = @pry_input_pipe_read
       Readline.output = @pry_output_pty_write
       @repling = true

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 require 'pty'
-require 'ruby_jard/commands/validation_helpers'
-require 'ruby_jard/commands/continue_command'
-require 'ruby_jard/commands/up_command'
-require 'ruby_jard/commands/down_command'
-require 'ruby_jard/commands/next_command'
-require 'ruby_jard/commands/step_command'
-require 'ruby_jard/commands/step_out_command'
-require 'ruby_jard/commands/frame_command'
-require 'ruby_jard/commands/list_command'
-require 'ruby_jard/commands/color_scheme_command'
 
 module RubyJard
   ##
@@ -46,7 +36,6 @@ module RubyJard
       'stat',          # Included in jard UI
       'backtrace',     # Re-implemented later
       'break',         # Re-implemented later
-      'exit',          # Conflicted with continue
       'exit-all',      # Conflicted with continue
       'exit-program',  # We already have `exit` native command
       '!pry',          # No need to complicate things

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -128,6 +128,7 @@ module RubyJard
     def pry_pty_output
       loop do
         STDOUT.print @pry_output_pty_read.read_nonblock(255)
+        STDOUT.flush
       rescue IO::WaitReadable, IO::WaitWritable
         # Retry
         sleep PTY_OUTPUT_TIMEOUT

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -124,7 +124,7 @@ module RubyJard
       draw_box(@screens)
       draw_screens(@screens)
 
-      RubyJard::Console.move_to(@output, 0, total_screen_height(@layouts) + 1)
+      RubyJard::Console.move_to(@output, 0, total_screen_height(@layouts) + 2)
       RubyJard::Console.clear_screen_to_end(@output)
 
       draw_debug(width, height)

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -124,7 +124,7 @@ module RubyJard
       draw_box(@screens)
       draw_screens(@screens)
 
-      RubyJard::Console.move_to(@output, 0, total_screen_height(@layouts) + 2)
+      RubyJard::Console.move_to(@output, 0, total_screen_height(@layouts) + 1)
       RubyJard::Console.clear_screen_to_end(@output)
 
       draw_debug(width, height)

--- a/spec/examples/test1_example.rb
+++ b/spec/examples/test1_example.rb
@@ -9,6 +9,7 @@ variable_d = { test: 1, this: 'Bye', array: nil }
 variable_e = /Wait, what/i
 variable_f = 1.1
 variable_g = 99..100
+variable_k = StandardError.new('A random error')
 
 jard
 variable_h = 15

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -46,9 +46,10 @@ class JardIntegrationTest
     sleep 1
 
     lines =
-      screen.split("\n")
-            .reject { |line| line.start_with?('jard >>') }
-            .reject { |line| line[1..line.length - 2]&.strip&.empty? }
+      screen
+      .split("\n")
+      .reject { |line| line.strip.include?('jard >>') }
+      .reject { |line| line[1..line.length - 2]&.strip&.empty? }
 
     lines.join("\n")
   end

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -48,7 +48,7 @@ class JardIntegrationTest
     lines =
       screen.split("\n")
             .reject { |line| line.start_with?('jard >>') }
-            .reject { |line| line[1..line.length - 2].strip.empty? }
+            .reject { |line| line[1..line.length - 2]&.strip&.empty? }
 
     lines.join("\n")
   end

--- a/spec/ruby_jard/commands/exit_command_spec.rb
+++ b/spec/ruby_jard/commands/exit_command_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyJard::Commands::ExitCommand do
+  subject(:command) { described_class.new }
+
+  it 'dispatches exit flow without arguments' do
+    flow = RubyJard::ControlFlow.listen do
+      command.process_line('exit')
+    end
+    expect(flow).to be_a(::RubyJard::ControlFlow)
+    expect(flow.command).to be(:exit)
+    expect(flow.arguments).to eql({})
+  end
+end

--- a/spec/ruby_jard/screens/source/source_screen_spec.rb
+++ b/spec/ruby_jard/screens/source/source_screen_spec.rb
@@ -6,81 +6,81 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
   context 'when jard stops at top-level binding' do
     let(:expected_output_1) do
       <<~EXPECTED
-        ┌ Source  ../../../examples/test1_example.rb:14 ───────────────────────────────┐
-        │   5 var_a = 123                                                              │
+        ┌ Source  ../../../examples/test1_example.rb:15 ───────────────────────────────┐
         │   6 var_b = 'hello world'                                                    │
         │   7 var_c = ['Hello', 1, 2, 3]                                               │
         │   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
         │   9 variable_e = /Wait, what/i                                               │
         │  10 variable_f = 1.1                                                         │
         │  11 variable_g = 99..100                                                     │
-        │  12                                                                          │
-        │  13 jard                                                                     │
-        │➠ 14 variable_h = 15                                                          │
-        │  15                                                                          │
-        │  16 jard                                                                     │
-        │  17 1.times {}                                                               │
-        │  18                                                                          │
-        │  19 jard                                                                     │
-        │  20 var_a + variable_f + variable_h || 5                                     │
+        │  12 variable_k = StandardError.new('A random error')                         │
+        │  13                                                                          │
+        │  14 jard                                                                     │
+        │➠ 15 variable_h = 15                                                          │
+        │  16                                                                          │
+        │  17 jard                                                                     │
+        │  18 1.times {}                                                               │
+        │  19                                                                          │
+        │  20 jard                                                                     │
+        │  21 var_a + variable_f + variable_h || 5                                     │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end
 
     let(:expected_output_2) do
       <<~EXPECTED
-        ┌ Source  ../../../examples/test1_example.rb:16 ───────────────────────────────┐
-        │   7 var_c = ['Hello', 1, 2, 3]                                               │
+        ┌ Source  ../../../examples/test1_example.rb:17 ───────────────────────────────┐
         │   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
         │   9 variable_e = /Wait, what/i                                               │
         │  10 variable_f = 1.1                                                         │
         │  11 variable_g = 99..100                                                     │
-        │  12                                                                          │
-        │  13 jard                                                                     │
-        │  14 variable_h = 15                                                          │
-        │  15                                                                          │
-        │➠ 16 jard                                                                     │
-        │  17 1.times {}                                                               │
-        │  18                                                                          │
-        │  19 jard                                                                     │
-        │  20 var_a + variable_f + variable_h || 5                                     │
+        │  12 variable_k = StandardError.new('A random error')                         │
+        │  13                                                                          │
+        │  14 jard                                                                     │
+        │  15 variable_h = 15                                                          │
+        │  16                                                                          │
+        │➠ 17 jard                                                                     │
+        │  18 1.times {}                                                               │
+        │  19                                                                          │
+        │  20 jard                                                                     │
+        │  21 var_a + variable_f + variable_h || 5                                     │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end
 
     let(:expected_output_3) do
       <<~EXPECTED
-        ┌ Source  ../../../examples/test1_example.rb:17 ───────────────────────────────┐
-        │   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
+        ┌ Source  ../../../examples/test1_example.rb:18 ───────────────────────────────┐
         │   9 variable_e = /Wait, what/i                                               │
         │  10 variable_f = 1.1                                                         │
         │  11 variable_g = 99..100                                                     │
-        │  12                                                                          │
-        │  13 jard                                                                     │
-        │  14 variable_h = 15                                                          │
-        │  15                                                                          │
-        │  16 jard                                                                     │
-        │➠ 17 1.times {}                                                               │
-        │  18                                                                          │
-        │  19 jard                                                                     │
-        │  20 var_a + variable_f + variable_h || 5                                     │
+        │  12 variable_k = StandardError.new('A random error')                         │
+        │  13                                                                          │
+        │  14 jard                                                                     │
+        │  15 variable_h = 15                                                          │
+        │  16                                                                          │
+        │  17 jard                                                                     │
+        │➠ 18 1.times {}                                                               │
+        │  19                                                                          │
+        │  20 jard                                                                     │
+        │  21 var_a + variable_f + variable_h || 5                                     │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end
 
     let(:expected_output_4) do
       <<~EXPECTED
-        ┌ Source  ../../../examples/test1_example.rb:20 ───────────────────────────────┐
-        │  11 variable_g = 99..100                                                     │
-        │  12                                                                          │
-        │  13 jard                                                                     │
-        │  14 variable_h = 15                                                          │
-        │  15                                                                          │
-        │  16 jard                                                                     │
-        │  17 1.times {}                                                               │
-        │  18                                                                          │
-        │  19 jard                                                                     │
-        │➠ 20 var_a + variable_f + variable_h || 5                                     │
+        ┌ Source  ../../../examples/test1_example.rb:21 ───────────────────────────────┐
+        │  12 variable_k = StandardError.new('A random error')                         │
+        │  13                                                                          │
+        │  14 jard                                                                     │
+        │  15 variable_h = 15                                                          │
+        │  16                                                                          │
+        │  17 jard                                                                     │
+        │  18 1.times {}                                                               │
+        │  19                                                                          │
+        │  20 jard                                                                     │
+        │➠ 21 var_a + variable_f + variable_h || 5                                     │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end

--- a/spec/ruby_jard/screens/source/source_screen_spec.rb
+++ b/spec/ruby_jard/screens/source/source_screen_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'RubyJard::Screens::SourceScreen' do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/screens/source') }
 
-  context 'with TOPLEVEL_BINDING code' do
+  context 'when jard stops at top-level binding' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Source  ../../../examples/test1_example.rb:14 ───────────────────────────────┐
@@ -100,7 +100,7 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
     end
   end
 
-  context 'with instance method' do
+  context 'when jard stops inside an instance method' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Source  ../../../examples/test2_example.rb:23 ───────────────────────────────┐
@@ -142,7 +142,7 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
     end
   end
 
-  context 'with nested method' do
+  context 'when jard stops within a nested method' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Source  ../../../examples/test4_example.rb:13 ───────────────────────────────┐
@@ -176,7 +176,7 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
     end
   end
 
-  context 'with jard putting at the beginning of file, as well as at the end of file' do
+  context 'when jard stops at the beginning of file or at the end of file' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Source  ../../../examples/test6_example.rb:2 ────────────────────────────────┐
@@ -195,7 +195,7 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
     end
   end
 
-  context 'with code evaluation' do
+  context 'when jard steps into a code evaluation' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Source  ../../../examples/test7_example.rb:21 ───────────────────────────────┐
@@ -317,7 +317,7 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
     end
   end
 
-  context 'when run with ruby -e' do
+  context 'when use jard with ruby -e' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Source  -e:3 ────────────────────────────────────────────────────────────────┐

--- a/spec/ruby_jard/screens/variables/variables_screen_spec.rb
+++ b/spec/ruby_jard/screens/variables/variables_screen_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'RubyJard::Screens::VariablesScreen' do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/screens/variables') }
 
-  context 'with TOPLEVEL_BINDING variables' do
+  context 'when jard stops at top-level binding' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -65,7 +65,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'with context inside an instance method' do
+  context 'when jard stops at an instance method' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -124,7 +124,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'with context inside a class method' do
+  context 'when jard stops inside a class method' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -146,7 +146,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'with context inside a nested loop' do
+  context 'when jard stops inside a nested loop' do
     let(:expected_output) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -235,7 +235,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'with code evaluation' do
+  context 'when jard steps into a code evaluation' do
     let(:expected_output_1) do
       <<~'EXPECTED'
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -280,7 +280,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'when stop at the end of a method' do
+  context 'when jard stops at the end of a method' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐
@@ -311,7 +311,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
     end
   end
 
-  context 'when run with ruby -e' do
+  context 'when use jard with ruby -e' do
     let(:expected_output_1) do
       <<~EXPECTED
         ┌ Variables ───────────────────────────────────────────────────────────────────┐

--- a/spec/ruby_jard/screens/variables/variables_screen_spec.rb
+++ b/spec/ruby_jard/screens/variables/variables_screen_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
         │  variable_f = 1.1                                                            │
         │  variable_g = 99..100                                                        │
         │• variable_h = nil                                                            │
+        │  variable_k = #<StandardError: A random error>                               │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end
@@ -32,6 +33,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
         │  variable_f = 1.1                                                            │
         │  variable_g = 99..100                                                        │
         │  variable_h = 15                                                             │
+        │  variable_k = #<StandardError: A random error>                               │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end
@@ -48,6 +50,7 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
         │• variable_f = 1.1                                                            │
         │  variable_g = 99..100                                                        │
         │• variable_h = 15                                                             │
+        │  variable_k = #<StandardError: A random error>                               │
         └──────────────────────────────────────────────────────────────────────────────┘
       EXPECTED
     end


### PR DESCRIPTION
## Bug fix: Auto-completion of pry (actually readline) is broken. 

The root cause of this bug is due to the current piping mechanism in Proxy. Readline's input is redirected to a pipe, but the output is to write directly on current STDOUT. While the process is fetching chars from STDIN under raw mode, it conflicts with Readline's output, and makes all Readline's output printed as raw mode.

The solution is to create a pty (to reserve all the escape sequences), create another thread just to output everything in the pty master conditionally. This is also an approach to standardize the integration between tty sessions (https://ruby-doc.org/stdlib-2.5.3/libdoc/pty/rdoc/PTY.html).
 
## Bug fix: Could not exit when starting Jard inside irb

Irb catches the exit function, and doesn't handle it well after jard session starts. So, I treats `exit` as a custom command, and trigger `Kernel#exit` directly.
