### PR TITLE
Enhance program output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `alias_to_debugger` option
 - Add `layout` option
 - Source screen: Use relative path if shorter than absolute path.
+- Add `show-output` command
 
 ### Bug fixes
 - Jard doesn't work when place at the end of a method, or a block.
@@ -19,6 +20,7 @@
 ### Internal & Refactoring
 - Add tests for critical sections
 - Use PTY to feed output from pry to actual STDOUT
+- Use a custom pager to allow internal customization
 
 ## [0.2.2 - Alpha 3]
 

--- a/lib/ruby_jard/commands/show_output_command.rb
+++ b/lib/ruby_jard/commands/show_output_command.rb
@@ -18,7 +18,7 @@ module RubyJard
       end
 
       def process
-        pry_instance.pager.open do |pager|
+        pry_instance.pager.open(pager_start_at_the_end: true) do |pager|
           self.class.output_storage.rewind
           pager.write self.class.output_storage.read until self.class.output_storage.eof?
         end

--- a/lib/ruby_jard/commands/show_output_command.rb
+++ b/lib/ruby_jard/commands/show_output_command.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RubyJard
+  module Commands
+    # Command used to explore stacktrace.
+    class ShowOutputCommand < Pry::ClassCommand
+      group 'RubyJard'
+      description 'Show all current program output'
+
+      match 'show-output'
+
+      banner <<-BANNER
+        Usage: show-output
+      BANNER
+
+      def self.output_storage
+        RubyJard::ScreenManager.instance.output_storage
+      end
+
+      def process
+        pry_instance.pager.open do |pager|
+          self.class.output_storage.rewind
+          pager.write self.class.output_storage.read until self.class.output_storage.eof?
+        end
+      end
+    end
+  end
+end
+
+Pry::Commands.add_command(RubyJard::Commands::ShowOutputCommand)

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -15,14 +15,12 @@ module RubyJard
     end
 
     def open(options = {})
-      pager = LessPager.new(@pry_instance.output, **options)
+      pager = LessPager.new(@pry_instance, **options)
       yield pager
     rescue Pry::Pager::StopPaging
       # Ignore
     ensure
       pager.close
-      prompt = @pry_instance.prompt.wait_proc.call
-      @pry_instance.output.puts "#{prompt}Tips: You can use `list` command to show back debugger screens"
     end
 
     private
@@ -34,8 +32,9 @@ module RubyJard
     ##
     # Pager using GNU Less
     class LessPager < Pry::Pager::NullPager
-      def initialize(out, force_open: false, pager_start_at_the_end: false)
-        super(out)
+      def initialize(pry_instance, force_open: false, pager_start_at_the_end: false)
+        super(pry_instance.output)
+        @pry_instance = pry_instance
         @buffer = ''
 
         @pager_start_at_the_end = pager_start_at_the_end
@@ -62,6 +61,9 @@ module RubyJard
       def close
         if invoked_pager?
           @pager.close
+          prompt = @pry_instance.prompt.wait_proc.call
+          # TODO: should show this tip even pager not invoked, when the size exceed a certain height
+          @out.puts "#{prompt}Tips: You can use `list` command to show back debugger screens"
         else
           @out.write @buffer
         end

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module RubyJard
+  ##
+  # Override Pry's pager system. Again, Pry doesn't support customizing pager. So...
+  class Pager
+    def initialize(pry_instance)
+      @pry_instance = pry_instance
+    end
+
+    def page(text)
+      open do |pager|
+        pager << text
+      end
+    end
+
+    def open(options = {})
+      pager = LessPager.new(@pry_instance.output, **options)
+      yield pager
+    rescue Pry::Pager::StopPaging
+      # Ignore
+    ensure
+      pager.close
+      prompt = @pry_instance.prompt.wait_proc.call
+      @pry_instance.output.puts "#{prompt}Tips: You can use `list` command to show back debugger screens"
+    end
+
+    private
+
+    def enabled?
+      !!@enabled
+    end
+
+    ##
+    # Pager using GNU Less
+    class LessPager < Pry::Pager::NullPager
+      def initialize(out, force_open: false, pager_start_at_the_end: false)
+        super(out)
+        @buffer = ''
+
+        @pager_start_at_the_end = pager_start_at_the_end
+
+        @tracker = Pry::Pager::PageTracker.new(height, width)
+        @pager = force_open ? open_pager : nil
+      end
+
+      def write(str)
+        if invoked_pager?
+          @pager.write str
+        else
+          @tracker.record str
+          @buffer += str
+          if @tracker.page?
+            @pager = open_pager
+            @pager.write(str)
+          end
+        end
+      rescue Errno::EPIPE
+        raise Pry::Pager::StopPaging
+      end
+
+      def close
+        if invoked_pager?
+          @pager.close
+        else
+          @out.write @buffer
+        end
+      end
+
+      def invoked_pager?
+        @pager
+      end
+
+      def open_pager
+        less_command = ['less', '-R', '-X', '-F', '-J']
+        less_command << '+G' if @pager_start_at_the_end
+        IO.popen(less_command.join(' '), 'w')
+      end
+    end
+  end
+end

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -11,6 +11,7 @@ require 'ruby_jard/commands/step_out_command'
 require 'ruby_jard/commands/frame_command'
 require 'ruby_jard/commands/list_command'
 require 'ruby_jard/commands/color_scheme_command'
+require 'ruby_jard/commands/show_output_command'
 
 module RubyJard
   ##

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -245,6 +245,10 @@ module RubyJard
         end
         alias_method :_original_handle_line, :handle_line
         alias_method :handle_line, :_jard_handle_line
+
+        def pager
+          RubyJard::Pager.new(self)
+        end
       end
       pry_instance
     end

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -158,14 +158,14 @@ module RubyJard
       loop do
         if exiting?
           if @pry_output_pty_read.ready?
-            STDOUT.print @pry_output_pty_read.read_nonblock(255)
+            STDOUT.write @pry_output_pty_read.read_nonblock(255), from_jard: true
           else
             exited!
           end
         elsif exited?
           sleep PTY_OUTPUT_TIMEOUT
         else
-          STDOUT.print @pry_output_pty_read.read_nonblock(255)
+          STDOUT.write @pry_output_pty_read.read_nonblock(255), from_jard: true
         end
       rescue IO::WaitReadable, IO::WaitWritable
         # Retry

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -39,6 +39,8 @@ require 'ruby_jard/layout'
 require 'ruby_jard/layouts'
 require 'ruby_jard/layout_calculator'
 
+require 'ruby_jard/pager'
+
 module RubyJard
   ##
   # This class acts as a coordinator, in which it combines the data and screen


### PR DESCRIPTION
- Exclude jard-generated output in repl
- Implement `show-output` command.
- If output is small enough to fit into a small screen:

![Screenshot from 2020-08-09 01-43-29](https://user-images.githubusercontent.com/11613517/89717541-c4274b80-d9e1-11ea-935f-f562fe4ec885.png)

- If output exceeds the height of the screen:
![Screenshot from 2020-08-09 01-43-04](https://user-images.githubusercontent.com/11613517/89717639-b45c3700-d9e2-11ea-9ad6-ef98f59912c9.png)

- Show tips if the real pager is invoked.
