### PR TITLE
Auto-adjust layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `show-output` command
 - Move variable screen to the right again (sorry :pray:)
 - Auto-adjust screens to utilize spaces on the screen
+- Small colorless friendly adjustment to variable and thread marks
 
 ### Bug fixes
 - Jard doesn't work when place at the end of a method, or a block.
@@ -19,6 +20,7 @@
 - Auto-completion of pry (actually readline) is broken
 - Could not exit when starting Jard inside irb
 - Repl is broken if the keyboard repeat rate is too high.
+- Fix broken frame command
 
 ### Internal & Refactoring
 - Add tests for critical sections
@@ -26,6 +28,7 @@
 - Use a custom pager to allow internal customization
 - Improve performance of Jard when working with process with plenty of threads
 - Handle key-binding spamming well
+- Lazily load row data
 
 ## [0.2.2 - Alpha 3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Add `gruvbox` color scheme
 - Add `alias_to_debugger` option
 - Add `layout` option
-- Source screen: Use relative path if shorter than absolute path.
+- Source screen: Use relative path if shorter than absolute path
 - Add `show-output` command
+- Move variable screen to the right again (sorry :pray:)
+- Auto-adjust screens to utilize spaces on the screen
 
 ### Bug fixes
 - Jard doesn't work when place at the end of a method, or a block.
@@ -16,6 +18,7 @@
 - Source screen doesn't work well with anonymous evaluation, or `ruby -e`
 - Auto-completion of pry (actually readline) is broken
 - Could not exit when starting Jard inside irb
+- Repl is broken if the keyboard repeat rate is too high.
 
 ### Internal & Refactoring
 - Add tests for critical sections

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 0.88'
 gem 'rubocop-rspec', require: false
+gem 'rspec-retry', group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,7 @@ gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 0.88'
 gem 'rubocop-rspec', require: false
-gem 'rspec-retry', group: :test
+
+group :test do
+  gem 'rspec-retry'
+end

--- a/lib/ruby_jard/commands/frame_command.rb
+++ b/lib/ruby_jard/commands/frame_command.rb
@@ -21,7 +21,7 @@ module RubyJard
       BANNER
 
       def self.session_backtrace
-        RubyJard.current_session.backtrace
+        RubyJard.current_session.current_backtrace
       end
 
       def process

--- a/lib/ruby_jard/layout.rb
+++ b/lib/ruby_jard/layout.rb
@@ -4,9 +4,15 @@ module RubyJard
   ##
   # Data object to store calculated layout
   class Layout
-    attr_accessor :template, :box_width, :box_height, :box_x, :box_y, :width, :height, :x, :y
+    attr_accessor :template, :parent_template,
+                  :box_width, :box_height, :box_x, :box_y,
+                  :width, :height, :x, :y
 
-    def initialize(template: nil, width: 0, height: 0, x: 0, y: 0, box_width: 0, box_height: 0, box_x: 0, box_y: 0)
+    def initialize(
+      template: nil, parent_template: nil,
+      width: 0, height: 0, x: 0, y: 0,
+      box_width: 0, box_height: 0, box_x: 0, box_y: 0
+    )
       @template = template
       @box_width = box_width
       @box_height = box_height
@@ -16,6 +22,7 @@ module RubyJard
       @height = height
       @x = x
       @y = y
+      @parent_template = parent_template
     end
   end
 end

--- a/lib/ruby_jard/layout_calculator.rb
+++ b/lib/ruby_jard/layout_calculator.rb
@@ -22,16 +22,16 @@ module RubyJard
 
     def calculate
       @layouts = []
-      calculate_layout(@layout_template, @width, @height, @x, @y)
+      calculate_layout(@layout_template, @width, @height, @x, @y, nil)
       @layouts
     end
 
     private
 
-    def calculate_layout(template, width, height, x, y)
+    def calculate_layout(template, width, height, x, y, parent_template)
       if template.is_a?(RubyJard::Templates::ScreenTemplate)
         layout = RubyJard::Layout.new(
-          template: template,
+          template: template, parent_template: parent_template,
           width: width - 2, height: height - 2, x: x + 1, y: y + 1,
           box_width: width, box_height: height, box_x: x, box_y: y
         )
@@ -64,10 +64,10 @@ module RubyJard
           child_x += child_width
         end
 
-        stretch_lines(template, width, height, lines)
+        stretch_children_layouts(template, width, height, lines)
         lines.each do |line|
           line.each do |child_template, child_width, child_height, xx, yy|
-            calculate_layout(child_template, child_width, child_height, xx, yy)
+            calculate_layout(child_template, child_width, child_height, xx, yy, template)
           end
         end
       end
@@ -89,7 +89,8 @@ module RubyJard
       end
     end
 
-    def stretch_lines(parent_template, parent_width, parent_height, lines)
+    # Stretch the children layouts to fill the gaps, remove redundant spaces inside the parent layout
+    def stretch_children_layouts(parent_template, parent_width, parent_height, lines)
       total_height = 0
       lines.each_with_index do |line, line_index|
         desired_height =

--- a/lib/ruby_jard/layouts/wide_layout.rb
+++ b/lib/ruby_jard/layouts/wide_layout.rb
@@ -14,7 +14,8 @@ module RubyJard
           children: [
             RubyJard::Templates::ScreenTemplate.new(
               screen: :source,
-              height_ratio: 70
+              height_ratio: 70,
+              adjust_mode: :expand
             ),
             RubyJard::Templates::ScreenTemplate.new(
               screen: :backtrace,
@@ -29,11 +30,12 @@ module RubyJard
           children: [
             RubyJard::Templates::ScreenTemplate.new(
               screen: :variables,
-              height_ratio: 60
+              height_ratio: 80,
+              adjust_mode: :expand
             ),
             RubyJard::Templates::ScreenTemplate.new(
               screen: :threads,
-              height_ratio: 40
+              height_ratio: 20
             )
           ]
         ),

--- a/lib/ruby_jard/layouts/wide_layout.rb
+++ b/lib/ruby_jard/layouts/wide_layout.rb
@@ -19,7 +19,8 @@ module RubyJard
             ),
             RubyJard::Templates::ScreenTemplate.new(
               screen: :backtrace,
-              height_ratio: 30
+              height_ratio: 30,
+              min_height: 3
             )
           ]
         ),
@@ -35,7 +36,8 @@ module RubyJard
             ),
             RubyJard::Templates::ScreenTemplate.new(
               screen: :threads,
-              height_ratio: 20
+              height_ratio: 20,
+              min_height: 3
             )
           ]
         ),

--- a/lib/ruby_jard/layouts/wide_layout.rb
+++ b/lib/ruby_jard/layouts/wide_layout.rb
@@ -10,18 +10,15 @@ module RubyJard
         RubyJard::Templates::LayoutTemplate.new(
           height_ratio: 80,
           width_ratio: 50,
-          min_height: 7,
           fill_height: true,
           children: [
             RubyJard::Templates::ScreenTemplate.new(
               screen: :source,
-              height_ratio: 60
+              height_ratio: 70
             ),
             RubyJard::Templates::ScreenTemplate.new(
-              screen: :variables,
-              width_ratio: 100,
-              height_ratio: 40,
-              min_height: 3
+              screen: :backtrace,
+              height_ratio: 30
             )
           ]
         ),
@@ -31,14 +28,12 @@ module RubyJard
           fill_height: true,
           children: [
             RubyJard::Templates::ScreenTemplate.new(
-              screen: :backtrace,
-              height_ratio: 50,
-              fill_height: true
+              screen: :variables,
+              height_ratio: 60
             ),
             RubyJard::Templates::ScreenTemplate.new(
               screen: :threads,
-              height_ratio: 50,
-              fill_height: true
+              height_ratio: 40
             )
           ]
         ),

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -115,7 +115,7 @@ module RubyJard
     def handle_frame_command(options)
       next_frame = options[:frame].to_i
       if Byebug::Frame.new(Byebug.current_context, next_frame).c_frame?
-        puts "Error: Frame #{next_frame} is a c-frame. Not able to inspect c layer!"
+        RubyJard::ScreenManager.puts "Error: Frame #{next_frame} is a c-frame. Not able to inspect c layer!"
         process_commands(false)
       else
         Byebug.current_context.frame = next_frame
@@ -125,7 +125,7 @@ module RubyJard
     end
 
     def handle_continue_command(_options = {})
-      # Do nothing
+      RubyJard::ScreenManager.puts '► ► Program resumed ► ►'
     end
 
     def handle_exit_command(_options = {})

--- a/lib/ruby_jard/row.rb
+++ b/lib/ruby_jard/row.rb
@@ -6,13 +6,26 @@ module RubyJard
   class Row
     extend Forwardable
 
-    attr_accessor :columns, :line_limit, :content
+    attr_accessor :columns, :line_limit, :content, :rendered
 
     def initialize(line_limit: 1, columns: [], ellipsis: true)
       @content = []
       @columns = columns
       @ellipsis = ellipsis
       @line_limit = line_limit
+      @rendered = false
+    end
+
+    def rendered?
+      @rendered == true
+    end
+
+    def mark_rendered
+      @rendered = true
+    end
+
+    def reset_rendered
+      @rendered = false
     end
   end
 end

--- a/lib/ruby_jard/row_renderer.rb
+++ b/lib/ruby_jard/row_renderer.rb
@@ -14,6 +14,8 @@ module RubyJard
     end
 
     def render
+      @row.reset_rendered
+
       @x = 0
       @y = 0
       @original_x = 0
@@ -35,6 +37,8 @@ module RubyJard
       end
 
       generate_bitmap
+
+      @row.mark_rendered
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/lib/ruby_jard/screen.rb
+++ b/lib/ruby_jard/screen.rb
@@ -15,7 +15,18 @@ module RubyJard
       @cursor = nil
       @selected = 0
       @rows = []
-      @need_to_render = true
+    end
+
+    def shrinkable?
+      @window.length < @layout.height
+    end
+
+    def schrinkable_height
+      if @window.length < @layout.height
+        @layout.height - @window.length
+      else
+        0
+      end
     end
 
     def move_down; end
@@ -30,14 +41,6 @@ module RubyJard
 
     def build
       raise NotImplementedError, "#{self.class} should implement this method."
-    end
-
-    def need_to_render?
-      @need_to_render == true
-    end
-
-    def mark_rendered!
-      @need_to_render = false
     end
   end
 end

--- a/lib/ruby_jard/screen.rb
+++ b/lib/ruby_jard/screen.rb
@@ -17,32 +17,6 @@ module RubyJard
       @rows = []
     end
 
-    def shrinkable?
-      case @layout.template.adjust_mode
-      when :expand
-        false
-      else
-        @window.length < @layout.height
-      end
-    end
-
-    def expandable?
-      case @layout.template.adjust_mode
-      when :expand
-        true
-      else
-        @window.length >= @layout.height
-      end
-    end
-
-    def shrinkable_height
-      if @window.length < @layout.height
-        @layout.height - @window.length
-      else
-        0
-      end
-    end
-
     def move_down; end
 
     def move_up; end

--- a/lib/ruby_jard/screen.rb
+++ b/lib/ruby_jard/screen.rb
@@ -18,10 +18,24 @@ module RubyJard
     end
 
     def shrinkable?
-      @window.length < @layout.height
+      case @layout.template.adjust_mode
+      when :expand
+        false
+      else
+        @window.length < @layout.height
+      end
     end
 
-    def schrinkable_height
+    def expandable?
+      case @layout.template.adjust_mode
+      when :expand
+        true
+      else
+        @window.length >= @layout.height
+      end
+    end
+
+    def shrinkable_height
       if @window.length < @layout.height
         @layout.height - @window.length
       else

--- a/lib/ruby_jard/screen_adjuster.rb
+++ b/lib/ruby_jard/screen_adjuster.rb
@@ -7,23 +7,23 @@ module RubyJard
   # away those spaces to other screens. This layout adjustment is small, and
   # should not affect the original generated layout too much, nor work with
   # nested layout.
-  class ScreenShrinker
+  class ScreenAdjuster
     def initialize(screens)
       @screens = screens
     end
 
-    def shrink
+    def adjust
       groups = @screens.group_by { |screen| screen.layout.parent_template }
       groups.each do |_, grouped_screens|
         next if grouped_screens.length <= 1
 
         grouped_screens.sort_by! { |screen| screen.layout.box_y }
         shrinkable_screens = grouped_screens.select(&:shrinkable?)
-        expandable_screens = grouped_screens.reject(&:shrinkable?)
+        expandable_screens = grouped_screens.select(&:expandable?)
 
         next if shrinkable_screens.empty? || expandable_screens.empty?
 
-        budget = shrinkable_screens.map(&:schrinkable_height).sum
+        budget = shrinkable_screens.map(&:shrinkable_height).sum
         expand_screens(expandable_screens, budget)
         shrink_screens(shrinkable_screens)
         compact_screens(grouped_screens)
@@ -49,7 +49,7 @@ module RubyJard
 
     def shrink_screens(shrinkable_screens)
       shrinkable_screens.each do |screen|
-        delta = screen.schrinkable_height
+        delta = screen.shrinkable_height
         screen.layout.height -= delta
         screen.layout.box_height -= delta
       end

--- a/lib/ruby_jard/screen_adjuster.rb
+++ b/lib/ruby_jard/screen_adjuster.rb
@@ -84,7 +84,11 @@ module RubyJard
 
     def shrinkable_height(screen)
       if screen.window.length < screen.layout.height
-        screen.layout.height - screen.window.length
+        window_height = screen.window.length
+        if !screen.layout.template.min_height.nil? && screen.layout.template.min_height > window_height
+          window_height = screen.layout.template.min_height
+        end
+        screen.layout.height - window_height
       else
         0
       end

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -23,7 +23,7 @@ require 'ruby_jard/column'
 require 'ruby_jard/span'
 require 'ruby_jard/row_renderer'
 require 'ruby_jard/screen_renderer'
-require 'ruby_jard/screen_shrinker'
+require 'ruby_jard/screen_adjuster'
 require 'ruby_jard/box_drawer'
 require 'ruby_jard/screen_drawer'
 
@@ -184,11 +184,14 @@ module RubyJard
         render_screen(screen)
         screen
       end
-      RubyJard::ScreenShrinker.new(screens).shrink
-      screens.each do |screen|
+      RubyJard::ScreenAdjuster.new(screens).adjust
+      layouts.map do |layout|
+        screen_class = fetch_screen(layout.template.screen)
+        screen = screen_class.new(layout: layout)
+        screen.build
         render_screen(screen)
+        screen
       end
-      screens
     end
 
     def draw_box(screens)

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -23,6 +23,7 @@ require 'ruby_jard/column'
 require 'ruby_jard/span'
 require 'ruby_jard/row_renderer'
 require 'ruby_jard/screen_renderer'
+require 'ruby_jard/screen_shrinker'
 require 'ruby_jard/box_drawer'
 require 'ruby_jard/screen_drawer'
 
@@ -176,15 +177,18 @@ module RubyJard
     end
 
     def build_screens(layouts)
-      layouts.map do |layout|
+      screens = layouts.map do |layout|
         screen_class = fetch_screen(layout.template.screen)
-        screen = screen_class.new(
-          layout: layout
-        )
+        screen = screen_class.new(layout: layout)
         screen.build
         render_screen(screen)
         screen
       end
+      RubyJard::ScreenShrinker.new(screens).shrink
+      screens.each do |screen|
+        render_screen(screen)
+      end
+      screens
     end
 
     def draw_box(screens)

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -49,7 +49,7 @@ module RubyJard
     class << self
       extend Forwardable
 
-      def_delegators :instance, :update, :draw_error, :started?, :updating?
+      def_delegators :instance, :update, :puts, :draw_error, :started?, :updating?
 
       def instance
         @instance ||= new
@@ -158,6 +158,10 @@ module RubyJard
         @output.puts exception.backtrace.first(10)
       end
       @output.puts '-------------'
+    end
+
+    def puts(content)
+      @output.write "#{content}\n", from_jard: true
     end
 
     private

--- a/lib/ruby_jard/screen_renderer.rb
+++ b/lib/ruby_jard/screen_renderer.rb
@@ -11,14 +11,11 @@ module RubyJard
     end
 
     def render
-      return unless @screen.need_to_render?
-
       # Move this logic into a class called SreenRenderer
       calculate_content_lengths
       column_widths = calculate_column_widths
       adjust_column_widths(column_widths)
       calculate_window
-      @screen.mark_rendered!
 
       @screen
     end

--- a/lib/ruby_jard/screen_renderer.rb
+++ b/lib/ruby_jard/screen_renderer.rb
@@ -17,7 +17,6 @@ module RubyJard
       calculate_content_lengths
       column_widths = calculate_column_widths
       adjust_column_widths(column_widths)
-      render_rows
       calculate_window
       @screen.mark_rendered!
 
@@ -91,12 +90,6 @@ module RubyJard
 
     def render_rows
       @screen.rows.each do |row|
-        RubyJard::RowRenderer.new(
-          row: row,
-          width: @screen.layout.width,
-          height: @screen.layout.height,
-          color_scheme: @color_scheme
-        ).render
       end
     end
 
@@ -112,7 +105,7 @@ module RubyJard
 
     def find_seleted_window
       @screen.rows.each_with_index do |row, row_index|
-        row.content.each_with_index do |line, line_index|
+        row_content(row).each_with_index do |line, line_index|
           if @screen.window.length < @screen.layout.height
             @screen.window << line
           elsif row_index < @screen.selected
@@ -134,7 +127,7 @@ module RubyJard
     def find_cursor_window
       cursor_line = -1
       @screen.rows.each do |row|
-        row.content.each do |line|
+        row_content(row).each do |line|
           cursor_line += 1
           @screen.window << line if cursor_line >= @screen.cursor
           return if @screen.window.length >= @screen.layout.height
@@ -144,6 +137,19 @@ module RubyJard
 
     def count_columns
       @screen.rows.map { |row| row.columns.count }.max.to_i
+    end
+
+    def row_content(row)
+      unless row.rendered?
+        RubyJard::RowRenderer.new(
+          row: row,
+          width: @screen.layout.width,
+          height: @screen.layout.height,
+          color_scheme: @color_scheme
+        ).render
+      end
+
+      row.content
     end
   end
 end

--- a/lib/ruby_jard/screen_shrinker.rb
+++ b/lib/ruby_jard/screen_shrinker.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module RubyJard
+  ##
+  # Implement elastic screen height. If a screen is shrinkable (which means)
+  # its current window is less than its height, it will be forced to give
+  # away those spaces to other screens. This layout adjustment is small, and
+  # should not affect the original generated layout too much, nor work with
+  # nested layout.
+  class ScreenShrinker
+    def initialize(screens)
+      @screens = screens
+    end
+
+    def shrink
+      groups = @screens.group_by { |screen| screen.layout.parent_template }
+      groups.each do |_, grouped_screens|
+        next if grouped_screens.length <= 1
+
+        grouped_screens.sort_by! { |screen| screen.layout.box_y }
+        shrinkable_screens = grouped_screens.select(&:shrinkable?)
+        expandable_screens = grouped_screens.reject(&:shrinkable?)
+
+        next if shrinkable_screens.empty? || expandable_screens.empty?
+
+        budget = shrinkable_screens.map(&:schrinkable_height).sum
+        expand_screens(expandable_screens, budget)
+        shrink_screens(shrinkable_screens)
+        compact_screens(grouped_screens)
+      end
+    end
+
+    private
+
+    def expand_screens(expandable_screens, budget)
+      budget_each = budget / expandable_screens.length
+
+      expandable_screens.each_with_index do |screen, index|
+        if index == expandable_screens.length - 1
+          screen.layout.height += budget
+          screen.layout.box_height += budget
+        else
+          screen.layout.height += budget_each
+          screen.layout.box_height += budget_each
+          budget_each -= budget_each
+        end
+      end
+    end
+
+    def shrink_screens(shrinkable_screens)
+      shrinkable_screens.each do |screen|
+        delta = screen.schrinkable_height
+        screen.layout.height -= delta
+        screen.layout.box_height -= delta
+      end
+    end
+
+    def compact_screens(screens)
+      box_y = screens.first.layout.box_y
+      screens.each do |screen|
+        screen.layout.box_y = box_y
+        screen.layout.y = box_y + 1
+        box_y += screen.layout.box_height - 1
+      end
+    end
+  end
+end

--- a/lib/ruby_jard/screens/backtrace_screen.rb
+++ b/lib/ruby_jard/screens/backtrace_screen.rb
@@ -39,12 +39,12 @@ module RubyJard
         frame_id_label = frame_id.to_s.rjust(frames_count.to_s.length)
         if current_frame?(frame_id)
           RubyJard::Span.new(
-            content: frame_id_label,
+            content: "➠ #{frame_id_label}",
             styles: :frame_id_highlighted
           )
         else
           RubyJard::Span.new(
-            content: frame_id_label,
+            content: "  #{frame_id_label}",
             styles: :frame_id
           )
         end

--- a/lib/ruby_jard/screens/threads_screen.rb
+++ b/lib/ruby_jard/screens/threads_screen.rb
@@ -42,10 +42,11 @@ module RubyJard
       private
 
       def span_mark(context)
+        style = thread_status_style(context.thread)
         RubyJard::Span.new(
           margin_right: 1,
-          content: '•',
-          styles: thread_status_style(context.thread)
+          content: style == :thread_status_run ? '►' : '•',
+          styles: style
         )
       end
 

--- a/lib/ruby_jard/templates/screen_template.rb
+++ b/lib/ruby_jard/templates/screen_template.rb
@@ -9,7 +9,7 @@ module RubyJard
       attr_reader :screen, :row_template, :height_ratio, :width_ratio,
                   :min_width, :min_height,
                   :height, :width,
-                  :fill_width, :fill_height
+                  :adjust_mode
 
       def initialize(
         screen: nil,
@@ -17,7 +17,7 @@ module RubyJard
         height_ratio: nil, width_ratio: nil,
         min_width: nil, min_height: nil,
         height: nil, width: nil,
-        fill_width: nil, fill_height: nil
+        adjust_mode: nil
       )
         @screen = screen
         @row_template = row_template
@@ -27,8 +27,7 @@ module RubyJard
         @min_height = min_height
         @height = height
         @width = width
-        @fill_width = fill_width
-        @fill_height = fill_height
+        @adjust_mode = adjust_mode
       end
     end
   end

--- a/spec/examples/erb_evaluation.erb
+++ b/spec/examples/erb_evaluation.erb
@@ -1,0 +1,8 @@
+<% capitalized_name = @name.upcase %>
+<h1><%= capitalized_name %></h1>
+<ul>
+  <% @prices.each do |price| %>
+    <% jard %>
+    <li><%= price %></li>
+  <% end %>
+</ul>

--- a/spec/examples/erb_evaluation.rb
+++ b/spec/examples/erb_evaluation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'ruby_jard'
+require 'erb'
+
+class ProductView
+  class ProductObject
+    attr_reader :name, :prices
+
+    def initialize(name, prices)
+      @name = name
+      @prices = prices
+    end
+  end
+
+  def initialize(name, prices)
+    @object = ProductObject.new(name, prices)
+  end
+
+  def render
+    file = File.join(File.dirname(__FILE__), './erb_evaluation.erb')
+    erb = ERB.new(File.read(file))
+    erb.filename = file
+    erb.result @object.__binding__
+  end
+end
+
+ProductView.new('Bitcoin', [5710, 5810]).render

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -17,9 +17,15 @@ class JardIntegrationTest
       '-d',
       '-c', @dir,
       '-s', @target,
-      '-n', 'main',
+      '-n', 'blank',
       "-x #{@width}",
-      "-y #{@height}",
+      "-y #{@height}"
+    )
+    tmux(
+      'new-window',
+      '-c', @dir,
+      '-t', @target,
+      '-n', 'main',
       @command
     )
     sleep 0.5

--- a/spec/ruby_jard/commands/color_scheme_command_integration_spec.rb
+++ b/spec/ruby_jard/commands/color_scheme_command_integration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'RubyJard::Commands::ColorSchemeCommand Integration tests' do
+RSpec.describe 'RubyJard::Commands::ColorSchemeCommand Integration tests', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/commands') }
 
   context 'when list color schemes' do
@@ -8,7 +8,7 @@ RSpec.describe 'RubyJard::Commands::ColorSchemeCommand Integration tests' do
       test = JardIntegrationTest.new(work_dir, "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb")
       test.start
       expect(test.screen_content).to match_repl(<<~SCREEN)
-        jard >> 
+        jard >>
       SCREEN
       test.send_keys('color-scheme -l', :Enter)
       expect(test.screen_content).to match_repl(<<~SCREEN)
@@ -28,11 +28,11 @@ RSpec.describe 'RubyJard::Commands::ColorSchemeCommand Integration tests' do
       test = JardIntegrationTest.new(work_dir, "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb")
       test.start
       expect(test.screen_content).to match_repl(<<~SCREEN)
-        jard >> 
+        jard >>
       SCREEN
       test.send_keys('color-scheme 256', :Enter)
       expect(test.screen_content).to match_repl(<<~SCREEN)
-        jard >> 
+        jard >>
       SCREEN
     ensure
       test.stop
@@ -44,7 +44,7 @@ RSpec.describe 'RubyJard::Commands::ColorSchemeCommand Integration tests' do
       test = JardIntegrationTest.new(work_dir, "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb")
       test.start
       expect(test.screen_content).to match_repl(<<~SCREEN)
-        jard >> 
+        jard >>
       SCREEN
       test.send_keys('color-scheme NotExistedScheme', :Enter)
       expect(test.screen_content).to match_repl(<<~SCREEN)

--- a/spec/ruby_jard/commands/show_output_command_integration_spec.rb
+++ b/spec/ruby_jard/commands/show_output_command_integration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'RubyJard::Commands::ShowOutputCommand Integration tests' do
+RSpec.describe 'RubyJard::Commands::ShowOutputCommand Integration tests', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/commands') }
 
   context 'when there is no output yet' do

--- a/spec/ruby_jard/screen_adjuster_spec.rb
+++ b/spec/ruby_jard/screen_adjuster_spec.rb
@@ -1,0 +1,356 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyJard::ScreenAdjuster do
+  let(:parent_template_a) { RubyJard::Templates::LayoutTemplate.new }
+
+  let(:template_1) { RubyJard::Templates::ScreenTemplate.new }
+  let(:layout_1) do
+    RubyJard::Layout.new(
+      box_width: 75, box_height: 41,
+      box_x: 72, box_y: 0,
+      width: 73, height: 39,
+      x: 73, y: 1,
+      template: template_1,
+      parent_template: parent_template_a
+    )
+  end
+
+  let(:template_2) { RubyJard::Templates::ScreenTemplate.new }
+  let(:layout_2) do
+    RubyJard::Layout.new(
+      box_width: 75, box_height: 12,
+      box_x: 72, box_y: 40,
+      width: 73, height: 10,
+      x: 73, y: 41,
+      template: template_2,
+      parent_template: parent_template_a
+    )
+  end
+
+  context 'when input nothing' do
+    let(:adjuster) { described_class.new([]) }
+
+    it 'does not raise exception' do
+      expect { adjuster.adjust }.not_to raise_exception
+    end
+  end
+
+  context 'when adjust only 1 screen' do
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:adjuster) { described_class.new([screen_1]) }
+
+    before do
+      screen_1.window = ['empty line'] * 40
+    end
+
+    it 'remains the current layout' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(41)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(39)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+    end
+  end
+
+  context 'when all of the screens still have spaces left' do
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 35
+      screen_2.window = ['empty line'] * 9
+    end
+
+    it 'remains the current layout' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(41)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(39)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(12)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(40)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(10)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(41)
+    end
+  end
+
+  context 'when first screen needs to expand and second one is shrinkable' do
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 39 # Right reaching the edge
+      screen_2.window = ['empty line'] * 5
+    end
+
+    it 'expands the first screen, and shrinks the second one' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(46)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(44)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(7)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(45)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(5)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(46)
+    end
+  end
+
+  context 'when second screen needs to expand and first one is shrinkable' do
+    let(:layout_3) do
+      RubyJard::Layout.new(
+        box_width: 75, box_height: 12,
+        box_x: 72, box_y: 0,
+        width: 73, height: 10,
+        x: 73, y: 1,
+        template: RubyJard::Templates::ScreenTemplate.new,
+        parent_template: parent_template_a
+      )
+    end
+    let(:screen_3) { RubyJard::Screen.new(layout: layout_3) }
+
+    let(:layout_4) do
+      RubyJard::Layout.new(
+        box_width: 75, box_height: 41,
+        box_x: 72, box_y: 12,
+        width: 73, height: 39,
+        x: 73, y: 13,
+        template: RubyJard::Templates::ScreenTemplate.new,
+        parent_template: parent_template_a
+      )
+    end
+    let(:screen_4) { RubyJard::Screen.new(layout: layout_4) }
+
+    let(:adjuster) { described_class.new([screen_3, screen_4]) }
+
+    before do
+      screen_3.window = ['empty line'] * 5
+      screen_4.window = ['empty line'] * 40 # Overflow the edge
+    end
+
+    it 'shrinks the first one, expands the second layout' do
+      adjuster.adjust
+      expect(layout_3.box_width).to eq(75)
+      expect(layout_3.box_height).to eq(7)
+      expect(layout_3.box_x).to eq(72)
+      expect(layout_3.box_y).to eq(0)
+      expect(layout_3.width).to eq(73)
+      expect(layout_3.height).to eq(5)
+      expect(layout_3.x).to eq(73)
+      expect(layout_3.y).to eq(1)
+
+      expect(layout_4.box_width).to eq(75)
+      expect(layout_4.box_height).to eq(46)
+      expect(layout_4.box_x).to eq(72)
+      expect(layout_4.box_y).to eq(6)
+      expect(layout_4.width).to eq(73)
+      expect(layout_4.height).to eq(44)
+      expect(layout_4.x).to eq(73)
+      expect(layout_4.y).to eq(7)
+    end
+  end
+
+  context 'when all of screens are full' do
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 39
+      screen_2.window = ['empty line'] * 10
+    end
+
+    it 'remains the current layout' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(41)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(39)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(12)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(40)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(10)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(41)
+    end
+  end
+
+  context 'when both screens have spaces left but the first one has expand mode' do
+    let(:template_1) { RubyJard::Templates::ScreenTemplate.new(adjust_mode: :expand) }
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 5
+      screen_2.window = ['empty line'] * 5
+    end
+
+    it 'expands the first screen, and shrinks the second one' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(46)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(44)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(7)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(45)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(5)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(46)
+    end
+  end
+
+  context 'when both screens have spaces left and both have expand mode' do
+    let(:template_1) { RubyJard::Templates::ScreenTemplate.new(adjust_mode: :expand) }
+    let(:template_2) { RubyJard::Templates::ScreenTemplate.new(adjust_mode: :expand) }
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 5
+      screen_2.window = ['empty line'] * 5
+    end
+
+    it 'remains the current layout' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(41)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(39)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(12)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(40)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(10)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(41)
+    end
+  end
+
+  context 'when the layout includes 2 columns' do
+    let(:parent_template_b) { RubyJard::Templates::LayoutTemplate.new }
+    let(:layout_3) do
+      RubyJard::Layout.new(
+        box_width: 73, box_height: 36,
+        box_x: 0, box_y: 0,
+        width: 71, height: 34,
+        x: 1, y: 1,
+        template: RubyJard::Templates::ScreenTemplate.new,
+        parent_template: parent_template_b
+      )
+    end
+    let(:layout_4) do
+      RubyJard::Layout.new(
+        box_width: 73, box_height: 17,
+        box_x: 0, box_y: 35,
+        width: 71, height: 15,
+        x: 1, y: 36,
+        template: RubyJard::Templates::ScreenTemplate.new,
+        parent_template: parent_template_b
+      )
+    end
+
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+    let(:screen_3) { RubyJard::Screen.new(layout: layout_3) }
+    let(:screen_4) { RubyJard::Screen.new(layout: layout_4) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2, screen_3, screen_4]) }
+
+    before do
+      screen_1.window = ['empty line'] * 39
+      screen_2.window = ['empty line'] * 5
+      screen_3.window = ['empty line'] * 34
+      screen_4.window = ['empty line'] * 10
+    end
+
+    it 'expands the first screen and third screen, shrinks the second and fourth one, grouped by column' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(46)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(44)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(7)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(45)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(5)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(46)
+
+      expect(layout_3.box_width).to eq(73)
+      expect(layout_3.box_height).to eq(41)
+      expect(layout_3.box_x).to eq(0)
+      expect(layout_3.box_y).to eq(0)
+      expect(layout_3.width).to eq(71)
+      expect(layout_3.height).to eq(39)
+      expect(layout_3.x).to eq(1)
+      expect(layout_3.y).to eq(1)
+
+      expect(layout_4.box_width).to eq(73)
+      expect(layout_4.box_height).to eq(12)
+      expect(layout_4.box_x).to eq(0)
+      expect(layout_4.box_y).to eq(40)
+      expect(layout_4.width).to eq(71)
+      expect(layout_4.height).to eq(10)
+      expect(layout_4.x).to eq(1)
+      expect(layout_4.y).to eq(41)
+    end
+  end
+end

--- a/spec/ruby_jard/screen_adjuster_spec.rb
+++ b/spec/ruby_jard/screen_adjuster_spec.rb
@@ -121,6 +121,40 @@ RSpec.describe RubyJard::ScreenAdjuster do
     end
   end
 
+  context 'when first screen needs to expand and second one has min_height attribute' do
+    let(:screen_1) { RubyJard::Screen.new(layout: layout_1) }
+    let(:template_2) { RubyJard::Templates::ScreenTemplate.new(min_height: 3) }
+    let(:screen_2) { RubyJard::Screen.new(layout: layout_2) }
+
+    let(:adjuster) { described_class.new([screen_1, screen_2]) }
+
+    before do
+      screen_1.window = ['empty line'] * 39 # Right reaching the edge
+      screen_2.window = ['empty line'] * 1
+    end
+
+    it 'expands the first screen, and shrinks the second one to min_height' do
+      adjuster.adjust
+      expect(layout_1.box_width).to eq(75)
+      expect(layout_1.box_height).to eq(48)
+      expect(layout_1.box_x).to eq(72)
+      expect(layout_1.box_y).to eq(0)
+      expect(layout_1.width).to eq(73)
+      expect(layout_1.height).to eq(46)
+      expect(layout_1.x).to eq(73)
+      expect(layout_1.y).to eq(1)
+
+      expect(layout_2.box_width).to eq(75)
+      expect(layout_2.box_height).to eq(5)
+      expect(layout_2.box_x).to eq(72)
+      expect(layout_2.box_y).to eq(47)
+      expect(layout_2.width).to eq(73)
+      expect(layout_2.height).to eq(3)
+      expect(layout_2.x).to eq(73)
+      expect(layout_2.y).to eq(48)
+    end
+  end
+
   context 'when second screen needs to expand and first one is shrinkable' do
     let(:layout_3) do
       RubyJard::Layout.new(

--- a/spec/ruby_jard/screens/source/source_screen_spec.rb
+++ b/spec/ruby_jard/screens/source/source_screen_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'RubyJard::Screens::SourceScreen' do
+RSpec.describe 'RubyJard::Screens::SourceScreen', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/screens/source') }
 
   context 'when jard stops at top-level binding' do

--- a/spec/ruby_jard/screens/source/source_screen_spec.rb
+++ b/spec/ruby_jard/screens/source/source_screen_spec.rb
@@ -336,4 +336,29 @@ RSpec.describe 'RubyJard::Screens::SourceScreen' do
       test.stop
     end
   end
+
+  context 'when jumping into an ERB file' do
+    let(:expected_output) do
+      <<~EXPECTED
+        ┌ Source  ../../../examples/erb_evaluation.erb:6 ──────────────────────────────┐
+        │   1 <% capitalized_name = @name.upcase %>                                    │
+        │   2 <h1><%= capitalized_name %></h1>                                         │
+        │   3 <ul>                                                                     │
+        │   4   <% @prices.each do |price| %>                                          │
+        │   5     <% jard %>                                                           │
+        │➠  6     <li><%= price %></li>                                                │
+        │   7   <% end %>                                                              │
+        │   8 </ul>                                                                    │
+        └──────────────────────────────────────────────────────────────────────────────┘
+      EXPECTED
+    end
+
+    it 'displays correct line' do
+      test = JardIntegrationTest.new(work_dir, "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb")
+      test.start
+      expect(test.screen_content).to match_screen(expected_output)
+    ensure
+      test.stop
+    end
+  end
 end

--- a/spec/ruby_jard/screens/variables/variables_screen_spec.rb
+++ b/spec/ruby_jard/screens/variables/variables_screen_spec.rb
@@ -348,4 +348,27 @@ RSpec.describe 'RubyJard::Screens::VariablesScreen' do
       test.stop
     end
   end
+
+  context 'when jumping into an ERB file' do
+    let(:expected_output) do
+      <<~'EXPECTED'
+        ┌ Variables ───────────────────────────────────────────────────────────────────┐
+        │  self = #<ProductView::ProductObject:??????????????????>                     │
+        │  capitalized_name = "BITCOIN"                                                │
+        │• price = 5710                                                                │
+        │  _erbout (len:39) = "\n<h1>BITCOIN</h1>\n<ul>\n  \n    \n    <li>"           │
+        │  @name = "Bitcoin"                                                           │
+        │  @prices (len:2) = [5710, 5810]                                              │
+        └──────────────────────────────────────────────────────────────────────────────┘
+      EXPECTED
+    end
+
+    it 'displays correct line' do
+      test = JardIntegrationTest.new(work_dir, "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb")
+      test.start
+      expect(test.screen_content).to match_screen(expected_output)
+    ensure
+      test.stop
+    end
+  end
 end

--- a/spec/ruby_jard/screens/variables/variables_screen_spec.rb
+++ b/spec/ruby_jard/screens/variables/variables_screen_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'RubyJard::Screens::VariablesScreen' do
+RSpec.describe 'RubyJard::Screens::VariablesScreen', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/ruby_jard/screens/variables') }
 
   context 'when jard stops at top-level binding' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'rspec/retry'
 require 'ruby_jard'
 
 RSPEC_ROOT = File.dirname __FILE__
@@ -16,6 +17,13 @@ require_relative_folder('./helpers/**/*')
 require_relative_folder('./shared/**/*')
 
 RSpec.configure do |config|
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+
+  config.around :each, :integration do |ex|
+    ex.run_with_retry retry: 3
+  end
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 


### PR DESCRIPTION
- Before:
![Screenshot from 2020-08-12 22-46-08](https://user-images.githubusercontent.com/11613517/90036798-a0b81580-dced-11ea-8b16-3993cf919e63.png)
- After:
![Screenshot from 2020-08-12 22-46-36](https://user-images.githubusercontent.com/11613517/90036871-b299b880-dced-11ea-95bd-de59c6b9519e.png)

Changes in this PR:
- Auto-adjust layouts to utilize all spaces on the screen. Non-important or less-data screen will denote its spaces for more crowded ones.
- Lazy-load rows in a screen
- Move variable screen to the right.