### PR TITLE
Enhance output stream

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,12 +16,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5
-    - name: Install tmux
-      run: sudo apt install -y tmux
-    - name: Start tmux
-      run: tmux start-server
-    - name: Test tmux
-      run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
     - name: Checking offenses
@@ -39,6 +33,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: sudo apt install -y tmux
+    - name: Update tmux setting:
+      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
     - name: Test tmux
@@ -60,6 +56,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: brew install tmux
+    - name: Update tmux setting:
+      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
     - name: Test tmux
@@ -83,6 +81,8 @@ jobs:
         ruby-version: 2.5
     - name: Install tmux
       run: sudo apt install -y tmux
+    - name: Update tmux setting:
+      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
     - name: Test tmux

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux start-server
+      run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
     - name: Checking offenses
@@ -38,7 +38,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux start-server
+      run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -57,7 +57,7 @@ jobs:
     - name: Install tmux
       run: brew install tmux
     - name: Start tmux
-      run: tmux start-server
+      run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -78,7 +78,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux start-server
+      run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,10 +33,10 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: sudo apt install -y tmux
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
+    - name: Update tmux setting
+      run: tmux set -s exit-empty off
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
@@ -56,10 +56,10 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: brew install tmux
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
+    - name: Update tmux setting
+      run: tmux set -s exit-empty off
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
@@ -81,10 +81,10 @@ jobs:
         ruby-version: 2.5
     - name: Install tmux
       run: sudo apt install -y tmux
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
+    - name: Update tmux setting
+      run: tmux set -s exit-empty off
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
+      run: tmux new-server
+    - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
@@ -38,6 +40,8 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
+      run: tmux new-server
+    - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
@@ -57,6 +61,8 @@ jobs:
     - name: Install tmux
       run: brew install tmux
     - name: Start tmux
+      run: tmux new-server
+    - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install
@@ -78,6 +84,8 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
+      run: tmux new-server
+    - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
       run: bundle install

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux new-server
+      run: tmux start-server
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux new-server
+      run: tmux start-server
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
     - name: Install tmux
       run: brew install tmux
     - name: Start tmux
-      run: tmux new-server
+      run: tmux start-server
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
     - name: Install tmux
       run: sudo apt install -y tmux
     - name: Start tmux
-      run: tmux new-server
+      run: tmux start-server
     - name: Test tmux
       run: tmux new-session -t testing -d
     - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,10 +35,10 @@ jobs:
       run: sudo apt install -y tmux
     - name: Start tmux
       run: tmux start-server
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
-    - name: Test tmux
-      run: tmux new-session -t testing -d
+    - name: Start dummy tmux session
+      run: tmux new-session -t dummy -d
+    - name: Wait for tmux
+      run: bundle exec ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -58,10 +58,10 @@ jobs:
       run: brew install tmux
     - name: Start tmux
       run: tmux start-server
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
-    - name: Test tmux
-      run: tmux new-session -t testing -d
+    - name: start dummy tmux session
+      run: tmux new-session -t dummy -d
+    - name: Wait for tmux
+      run: bundle exec ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -83,10 +83,10 @@ jobs:
       run: sudo apt install -y tmux
     - name: Start tmux
       run: tmux start-server
-    - name: Update tmux setting
-      run: tmux set -s exit-empty off
-    - name: Test tmux
-      run: tmux new-session -t testing -d
+    - name: start dummy tmux session
+      run: tmux new-session -t dummy -d
+    - name: Wait for tmux
+      run: bundle exec ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,7 +33,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: sudo apt install -y tmux
-    - name: Update tmux setting:
+    - name: Update tmux setting
       run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
@@ -56,7 +56,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: brew install tmux
-    - name: Update tmux setting:
+    - name: Update tmux setting
       run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server
@@ -81,7 +81,7 @@ jobs:
         ruby-version: 2.5
     - name: Install tmux
       run: sudo apt install -y tmux
-    - name: Update tmux setting:
+    - name: Update tmux setting
       run: tmux set -s exit-empty off
     - name: Start tmux
       run: tmux start-server

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Start dummy tmux session
       run: tmux new-session -t dummy -d
     - name: Wait for tmux
-      run: bundle exec ruby spec/wait_for_tmux.rb
+      run: ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -61,7 +61,7 @@ jobs:
     - name: start dummy tmux session
       run: tmux new-session -t dummy -d
     - name: Wait for tmux
-      run: bundle exec ruby spec/wait_for_tmux.rb
+      run: ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests
@@ -86,7 +86,7 @@ jobs:
     - name: start dummy tmux session
       run: tmux new-session -t dummy -d
     - name: Wait for tmux
-      run: bundle exec ruby spec/wait_for_tmux.rb
+      run: ruby spec/wait_for_tmux.rb
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/lib/ruby_jard.rb
+++ b/lib/ruby_jard.rb
@@ -43,10 +43,6 @@ require 'ruby_jard/version'
 module RubyJard
   class Error < StandardError; end
 
-  def self.current_session
-    @current_session ||= RubyJard::Session.new
-  end
-
   def self.benchmark(name)
     @benchmark_depth ||= 0
     @benchmark_depth += 1
@@ -94,7 +90,7 @@ end
 # Monkey-patch Kernel module to allow putting jard command anywhere.
 module Kernel
   def jard
-    RubyJard.current_session.attach
+    RubyJard::Session.instance.attach
   end
 
   if RubyJard.config.alias_to_debugger

--- a/lib/ruby_jard/commands/frame_command.rb
+++ b/lib/ruby_jard/commands/frame_command.rb
@@ -22,13 +22,13 @@ module RubyJard
 
       def initialize(context = {})
         super(context)
-        @session = context[:session] || RubyJard.current_session
+        @current_backtrace = (context[:session] || RubyJard::Session).current_backtrace
       end
 
       def process
         frame = validate_present!(args.first)
         frame = validate_non_negative_integer!(frame)
-        frame = validate_range!(frame, 0, @session.current_backtrace.length - 1)
+        frame = validate_range!(frame, 0, @current_backtrace.length - 1)
         RubyJard::ControlFlow.dispatch(:frame, frame: frame)
       end
     end

--- a/lib/ruby_jard/commands/jard/output_command.rb
+++ b/lib/ruby_jard/commands/jard/output_command.rb
@@ -19,7 +19,11 @@ module RubyJard
       end
 
       def process
-        pry_instance.pager.open(force_open: true, pager_start_at_the_end: true) do |pager|
+        pry_instance.pager.open(
+          force_open: true,
+          pager_start_at_the_end: true,
+          prompt: 'Program output'
+        ) do |pager|
           @session.output_buffer.each do |string|
             string.each do |s|
               pager.write(s)

--- a/lib/ruby_jard/commands/jard/output_command.rb
+++ b/lib/ruby_jard/commands/jard/output_command.rb
@@ -20,8 +20,11 @@ module RubyJard
 
       def process
         pry_instance.pager.open(force_open: true, pager_start_at_the_end: true) do |pager|
-          self.class.output_storage.rewind
-          pager.write self.class.output_storage.read_nonblock(2048) until self.class.output_storage.eof?
+          @session.output_buffer.each do |string|
+            string.each do |s|
+              pager.write(s)
+            end
+          end
         end
       end
     end

--- a/lib/ruby_jard/commands/jard/output_command.rb
+++ b/lib/ruby_jard/commands/jard/output_command.rb
@@ -13,8 +13,9 @@ module RubyJard
         Usage: output
       BANNER
 
-      def self.output_storage
-        RubyJard::ScreenManager.instance.output_storage
+      def initialize(*args)
+        super(*args)
+        @session = (context[:session] || RubyJard::Session)
       end
 
       def process

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -32,12 +32,13 @@ module RubyJard
     ##
     # Pager using GNU Less
     class LessPager < Pry::Pager::NullPager
-      def initialize(pry_instance, force_open: false, pager_start_at_the_end: false)
+      def initialize(pry_instance, force_open: false, pager_start_at_the_end: false, prompt: nil)
         super(pry_instance.output)
         @pry_instance = pry_instance
         @buffer = ''
 
         @pager_start_at_the_end = pager_start_at_the_end
+        @prompt = prompt
 
         @tracker = Pry::Pager::PageTracker.new(height, width)
         @pager = force_open ? open_pager : nil
@@ -78,6 +79,7 @@ module RubyJard
       def open_pager
         @pry_instance.exec_hook :before_pager, self
         less_command = ['less', '-R', '-X']
+        less_command << "--prompt \"#{@prompt}\"" if @prompt
         less_command << '+G' if @pager_start_at_the_end
 
         IO.popen(

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -45,7 +45,7 @@ module RubyJard
 
     def process_commands_with_lock
       allowing_other_threads do
-        RubyJard.current_session.lock do
+        RubyJard::Session.lock do
           process_commands
         end
       end
@@ -53,7 +53,7 @@ module RubyJard
 
     def process_commands(update = true)
       if update
-        RubyJard.current_session.update
+        RubyJard::Session.update
         RubyJard::ScreenManager.update
       end
       return_value = nil

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -49,6 +49,8 @@ module RubyJard
           process_commands
         end
       end
+    ensure
+      RubyJard::Session.flush_secondary_output_buffer
     end
 
     def process_commands(update = true)

--- a/lib/ruby_jard/screen.rb
+++ b/lib/ruby_jard/screen.rb
@@ -9,7 +9,7 @@ module RubyJard
     attr_accessor :layout, :rows, :window, :cursor, :selected
 
     def initialize(session: nil, layout:)
-      @session = session || RubyJard.current_session
+      @session = session || RubyJard::Session
       @layout = layout
       @window = []
       @cursor = nil

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -52,7 +52,6 @@ module RubyJard
 
       # Load configurations
       RubyJard.config
-      RubyJard::Console.start_alternative_terminal(@output)
       RubyJard::Console.clear_screen(@output)
 
       # rubocop:disable Lint/NestedMethodDefinition
@@ -83,13 +82,10 @@ module RubyJard
 
       @started = false
 
-      RubyJard::Console.stop_alternative_terminal(@output)
       RubyJard::Console.cooked!
       RubyJard::Console.enable_echo!
       RubyJard::Console.enable_cursor!
 
-      @output_storage.rewind
-      @output.write @output_storage.read until @output_storage.eof?
       @output_storage.close
       @output_storage.unlink
     end
@@ -98,6 +94,7 @@ module RubyJard
       start unless started?
       @updating = true
 
+      RubyJard::Console.clear_screen(@output)
       RubyJard::Console.disable_cursor!
       width, height = RubyJard::Console.screen_size(@output)
 

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -43,7 +43,6 @@ module RubyJard
       @screens = {}
       @started = false
       @updating = false
-      @output_storage = Tempfile.new('jard')
     end
 
     def start
@@ -53,18 +52,6 @@ module RubyJard
       RubyJard.config
       RubyJard::Console.clear_screen(@output)
 
-      # rubocop:disable Lint/NestedMethodDefinition
-      def $stdout.write(*string, from_jard: false)
-        # NOTE: `RubyJard::ScreenManager.instance` is a must. Jard doesn't work well with delegator
-        # TODO: Debug and fix the issues permanently
-        if !RubyJard::ScreenManager.instance.updating? && RubyJard::ScreenManager.instance.started? && !from_jard
-          RubyJard::ScreenManager.instance.output_storage.write(*string)
-        end
-        super(*string)
-      end
-      # rubocop:enable Lint/NestedMethodDefinition
-
-      at_exit { stop }
       @started = true
     end
 
@@ -84,9 +71,6 @@ module RubyJard
       RubyJard::Console.cooked!
       RubyJard::Console.enable_echo!
       RubyJard::Console.enable_cursor!
-
-      @output_storage.close
-      @output_storage.unlink
     end
 
     def update

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'tempfile'
 require 'ruby_jard/console'
 
 require 'ruby_jard/decorators/color_decorator'
@@ -30,7 +29,7 @@ module RubyJard
     class << self
       extend Forwardable
 
-      def_delegators :instance, :update, :puts, :draw_error, :started?, :updating?
+      def_delegators :instance, :update, :puts, :draw_error, :start, :stop, :started?, :updating?
 
       def instance
         @instance ||= new

--- a/lib/ruby_jard/screens/variables_screen.rb
+++ b/lib/ruby_jard/screens/variables_screen.rb
@@ -154,6 +154,8 @@ module RubyJard
       private
 
       def fetch_local_variables
+        return [] if @session.current_frame.nil?
+
         variables = @session.current_frame.frame_binding.local_variables
         # Exclude Pry's sticky locals
         pry_sticky_locals =
@@ -171,6 +173,8 @@ module RubyJard
       end
 
       def fetch_instance_variables
+        return [] if @session.current_frame.nil?
+
         @session.current_frame.frame_self.instance_variables.map do |variable|
           [KIND_INS, variable, @session.current_frame.frame_self.instance_variable_get(variable)]
         rescue NameError
@@ -179,6 +183,8 @@ module RubyJard
       end
 
       def fetch_constants
+        return [] if @session.current_frame.nil?
+
         # Filter out truly constants (CONSTANT convention) only
         constant_source =
           if @session.current_frame.frame_class&.singleton_class?

--- a/lib/ruby_jard/session.rb
+++ b/lib/ruby_jard/session.rb
@@ -86,14 +86,12 @@ module RubyJard
       @current_backtrace = current_context.backtrace.map.with_index do |_frame, index|
         RubyJard::Frame.new(current_context, index)
       end
-      @threads =
-        Byebug
-        .contexts
-        .reject(&:ignored?)
-        .reject { |c| c.thread.name.to_s =~ /<<Jard:.*>>/ }
-        .map do |context|
-          RubyJard::Frame.new(context, 0)
-        end
+      threads =
+        Thread
+        .list
+        .select(&:alive?)
+        .reject { |t| t.name.to_s =~ /<<Jard:.*>>/ }
+      @threads = threads.each_with_object({}) { |t, hash| hash[t] = t }
     end
 
     def lock

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -27,7 +27,6 @@ class JardIntegrationTest
       "-x #{@width}",
       "-y #{@height}"
     )
-    sleep 3 if ENV['CI']
     tmux(
       'new-window',
       '-c', @dir,
@@ -52,19 +51,11 @@ class JardIntegrationTest
       end
     end
     tmux('send-keys', '-t', @target, *args)
-    if ENV['CI']
-      sleep 3
-    else
-      sleep 0.5
-    end
+    sleep 0.5
   end
 
   def screen_content(allow_duplication = true)
-    if ENV['CI']
-      sleep 1
-    else
-      sleep 0.5
-    end
+    sleep 0.5
 
     previous_content = @content
     attempt = 5

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -63,10 +63,10 @@ class JardIntegrationTest
       @content = tmux('capture-pane', '-J', '-p', '-t', @target)
       break if allow_duplication
       break if attempt <= 0
-      break if !@content.to_s.strip.empty? && @content != previous_content
+      break if @content != previous_content
 
       attempt -= 1
-      sleep 0.5 * (5 - attempt)
+      sleep 0.5
     end
     @content
   end
@@ -88,6 +88,7 @@ end
 
 RSpec::Matchers.define :match_screen do |expected|
   match do |actual|
+    @raw = actual
     actual =
       actual
       .split("\n")
@@ -114,6 +115,11 @@ RSpec::Matchers.define :match_screen do |expected|
       Actual screen:
       ###
       #{actual}
+      ###
+
+      Raw screen:
+      ###
+      #{@raw}
       ###
     SCREEN
   end

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -63,10 +63,10 @@ class JardIntegrationTest
       @content = tmux('capture-pane', '-J', '-p', '-t', @target)
       break if allow_duplication
       break if attempt <= 0
-      break if @content != previous_content
+      break if !@content.to_s.strip.empty? && @content != previous_content
 
-      sleep 0.5
       attempt -= 1
+      sleep 0.5 * (5 - attempt)
     end
     @content
   end

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-
 class JardIntegrationTest
   def self.tests
     @tests ||= []
@@ -10,7 +8,7 @@ class JardIntegrationTest
   attr_reader :source
 
   def initialize(dir, command, width: 80, height: 24)
-    @target = "TestJard#{SecureRandom.uuid}"
+    @target = "TestJard#{rand(1..1000)}"
     @dir = dir
     @command = command
     @width = width
@@ -29,6 +27,7 @@ class JardIntegrationTest
       "-x #{@width}",
       "-y #{@height}"
     )
+    sleep 3 if ENV['CI']
     tmux(
       'new-window',
       '-c', @dir,

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -58,6 +58,8 @@ class JardIntegrationTest
     sleep 0.5
 
     previous_content = @content
+    sleep 3 if previous_content.nil? && ENV['CI']
+
     attempt = 5
     loop do
       @content = tmux('capture-pane', '-J', '-p', '-t', @target)

--- a/spec/integration/commands/show_output_spec.rb
+++ b/spec/integration/commands/show_output_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         ?
         ?
 
-        (END)
+        Program output
       SCREEN
     ensure
       test.stop
@@ -75,7 +75,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         10 | 7: abcdef
         10 | 8: abcdef
         10 | 9: abcdef
-        (END)
+        Program output
       SCREEN
     ensure
       test.stop
@@ -116,7 +116,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         100 | 97: xyz
         100 | 98: xyz
         100 | 99: xyz
-        (END)
+        Program output
       SCREEN
 
       test.send_keys('k')
@@ -144,7 +144,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         100 | 96: xyz
         100 | 97: xyz
         100 | 98: xyz
-        :
+        Program output
       SCREEN
 
       test.send_keys('g')
@@ -173,7 +173,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         100 | 10: xyz
         100 | 11: xyz
         100 | 12: xyz
-        :
+        Program output
       SCREEN
 
       test.send_keys('q')

--- a/spec/integration/commands/show_output_spec.rb
+++ b/spec/integration/commands/show_output_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Output Integration tests', integration: true do
         ?
         ?
         ?
-        ?
+
         (END)
       SCREEN
     ensure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,13 +32,18 @@ RSpec.configure do |config|
   end
 
   config.retry_callback = proc do
-    puts '==== Tmux ===='
-    begin
-      puts `tmux list-window`
-    rescue StandardError
-      # Ignore
+    if ENV['CI']
+      puts '==== Tmux ===='
+      begin
+        puts `tmux list-window`
+      rescue StandardError
+        # Ignore
+      end
+      puts 'Restart Tmux...'
+      puts `tmux kill-server`
+      puts `tmux start-server`
+      puts '==== End Tmux ===='
     end
-    puts '==== End Tmux ===='
   end
 
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
       puts `tmux kill-server`
       puts `tmux start-server`
       puts `tmux new-session -t dummy -d`
-      `bundle exec ruby spec/wait_for_tmux.rb`
+      `ruby spec/wait_for_tmux.rb`
       puts '==== End Tmux ===='
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,14 +34,19 @@ RSpec.configure do |config|
   config.retry_callback = proc do
     if ENV['CI']
       puts '==== Tmux ===='
+      puts 'Windows:'
       begin
         puts `tmux list-window`
       rescue StandardError
         # Ignore
       end
+      puts 'Info:'
+      puts `tmux info`
       puts 'Restart Tmux...'
       puts `tmux kill-server`
       puts `tmux start-server`
+      puts `tmux new-session -t dummy -d`
+      `bundle exec ruby spec/wait_for_tmux.rb`
       puts '==== End Tmux ===='
     end
   end

--- a/spec/wait_for_tmux.rb
+++ b/spec/wait_for_tmux.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'English'
+attempt = 10
+
+loop do
+  exit 1 if attempt <= 0
+  attempt -= 1
+  puts "Wait for tmux. Attempt #{attempt}"
+  test_result = `tmux info 2>&1`
+  if test_result =~ /no server/
+    sleep 1
+  else
+    exit 0
+  end
+end


### PR DESCRIPTION
- Remove alternative screen. Move back to screen clearing. It helps Jard reserve scrolling when explore huge objects. In return, the screen is clear. This is similar to gdb-dashboard. 
- `Byebug.contexts` degrades system performance dramatically. Thread screen uses only pure thread information. So, I replace contexts by `Thread.list` instead.
- Temp file is bad, really bad to use as a medium to store output. I replace it by in-memory ring buffer instead.
- Prevent other thread's output overflows the layout, by redirect other thread's output to a secondary buffer, and flush after the flow is done. 

Benchmark:
- A trivial Ruby code - 500k lines of logs to STDOUT
  + Byebug: 12 seconds
  + Jard: 13 seconds

- Rails app - 500k of logs printed to STDOUT:
  + Byebug: 6 seconds
  + Jard: 8 seconds

- Rails app - 500k of logs printed via Rails.logger:
  + Byebug: 7 seconds
  + Jard: 20 seconds (Hmmm. It looks Jard has a bottleneck somewhere - However, 500k lines of logs are not a common use cases, nearly useless if a user wants to explore though). 

This is a 3x to 4x improvement over the tempfile solution