### PR TITLE
Add Ctrl+D as a key binding for continue command

### DIFF
--- a/lib/ruby_jard/keys.rb
+++ b/lib/ruby_jard/keys.rb
@@ -42,7 +42,8 @@ module RubyJard
       F7       => (ACTION_STEP     = :step),
       SHIFT_F7 => (ACTION_STEP_OUT = :step_out),
       F8       => (ACTION_NEXT     = :next),
-      F9       => (ACTION_CONTINUE = :continue)
+      F9       => (ACTION_CONTINUE = :continue),
+      CTRL_D   => ACTION_CONTINUE
     }.freeze
   end
 end

--- a/spec/integration/key_bindings/key_bindings_spec.rb
+++ b/spec/integration/key_bindings/key_bindings_spec.rb
@@ -96,18 +96,36 @@ RSpec.describe 'Default key bindings', integration: true do
   end
 
   context 'with continue bindings' do
-    it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'record.continue_key_bindings',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F9)
-      test.assert_screen
-    ensure
-      test.stop
+    context 'with F9' do
+      it 'matches expected screens' do
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'record.continue_key_bindings',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F9)
+        test.assert_screen
+      ensure
+        test.stop
+      end
+    end
+
+    context 'with CTRL_D' do
+      it 'matches expected screens' do
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'record.continue_key_bindings_2',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:"C-d")
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 

--- a/spec/integration/key_bindings/record.continue_key_bindings_2
+++ b/spec/integration/key_bindings/record.continue_key_bindings_2
@@ -1,0 +1,55 @@
+### START SCREEN ###
+┌ Source  ../../examples/instance_method_2_example.rb:17 ──────────────────────┐
+│   9     d1 + d2                                                              │
+│  10   end                                                                    │
+│  11 end                                                                      │
+│  12                                                                          │
+│  13 class Calculator                                                         │
+│  14   def calculate(a, b, c)                                                 │
+│  15     d = a + b                                                            │
+│  16     jard                                                                 │
+│⮕ 17     e = SubCalculator.new.calculate(d)                                   │
+│  18     jard                                                                 │
+│  19     e + c                                                                │
+│  20   end                                                                    │
+│  21 end                                                                      │
+│  22                                                                          │
+│  23 Calculator.new.calculate(1, 2, 3)                                        │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+[:F9]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/instance_method_2_example.rb:19 ──────────────────────┐
+│  11 end                                                                      │
+│  12                                                                          │
+│  13 class Calculator                                                         │
+│  14   def calculate(a, b, c)                                                 │
+│  15     d = a + b                                                            │
+│  16     jard                                                                 │
+│  17     e = SubCalculator.new.calculate(d)                                   │
+│  18     jard                                                                 │
+│⮕ 19     e + c                                                                │
+│  20   end                                                                    │
+│  21 end                                                                      │
+│  22                                                                          │
+│  23 Calculator.new.calculate(1, 2, 3)                                        │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+
+
+### END SCREEN ###

--- a/spec/integration/key_bindings/record.continue_key_bindings_2
+++ b/spec/integration/key_bindings/record.continue_key_bindings_2
@@ -25,7 +25,7 @@ jard >>
 
 ### END SCREEN ###
 ### START SEND_KEYS ###
-[:F9]
+[:"C-d"]
 ### END SEND_KEYS ###
 ### START SCREEN ###
 ┌ Source  ../../examples/instance_method_2_example.rb:19 ──────────────────────┐

--- a/website/docs/guides/key_bindings.md
+++ b/website/docs/guides/key_bindings.md
@@ -12,6 +12,6 @@ slug: key-bindings
 | F7 | Detect and step into a method call or block in the current line | [step](/docs/commands/step) |
 | Shift F7 | Finish the execution of current frame, and jump to the next line of upper frame | [step-out](/docs/commands/step-out) |
 | F8 | Move to the next line | [next](/docs/commands/next) |
-| F9 | Continue the execution of your program to the end, or stop at the next break point | [continue](/docs/commands/continue) |
+| F9, Ctrl+D | Continue the execution of your program to the end, or stop at the next break point | [continue](/docs/commands/continue) |
 
 **Note**: Key binding customization is coming in index versions.


### PR DESCRIPTION
Ctrl D key binding doesn't work now. It should be the same as F9, an alias of continue command. This behavior is similar to Byebug, and pry.

Fix https://github.com/nguyenquangminh0711/ruby_jard/issues/34