### PR TITLE
Handle standard streams redirection

### DIFF
--- a/lib/ruby_jard/commands/jard/output_command.rb
+++ b/lib/ruby_jard/commands/jard/output_command.rb
@@ -19,6 +19,7 @@ module RubyJard
       end
 
       def process
+        sleep 0.25 # Cool down
         pry_instance.pager.open(
           force_open: true,
           pager_start_at_the_end: true,

--- a/lib/ruby_jard/console.rb
+++ b/lib/ruby_jard/console.rb
@@ -8,6 +8,10 @@ module RubyJard
   # Wrapper for utilities to control screen
   class Console
     class << self
+      def redirected?
+        output != $stdout
+      end
+
       def output
         return @output if defined?(@output)
 

--- a/lib/ruby_jard/console.rb
+++ b/lib/ruby_jard/console.rb
@@ -8,22 +8,26 @@ module RubyJard
   # Wrapper for utilities to control screen
   class Console
     class << self
-      def start_alternative_terminal(output)
-        return unless output.tty?
+      def output
+        return @output if defined?(@output)
 
-        output.print tput('smcup')
-      rescue RubyJard::Error
-        # If tput not found, fallback to hard-coded sequence.
-        output.print "\e[?1049h\e[22;0;0t"
+        @output =
+          if STDOUT.tty?
+            STDOUT
+          else
+            File.open('/dev/tty', 'w+')
+          end
       end
 
-      def stop_alternative_terminal(output)
-        return unless output.tty?
+      def input
+        return @input if defined?(@input)
 
-        output.print tput('rmcup')
-      rescue RubyJard::Error
-        # If tput not found, fallback to hard-coded sequence.
-        output.print "\e[?1049l\e[23;0;0t"
+        @input =
+          if STDIN.tty?
+            STDIN
+          else
+            File.open('/dev/tty', 'r+')
+          end
       end
 
       def move_to(output, x, y)
@@ -35,7 +39,12 @@ module RubyJard
       def screen_size(output)
         return [0, 0] unless output.tty?
 
-        [TTY::Screen.width, TTY::Screen.height]
+        if output.respond_to?(:winsize)
+          height, width = output.winsize
+          [width, height]
+        else
+          [TTY::Screen.width, TTY::Screen.height]
+        end
       end
 
       def clear_screen(output)
@@ -50,7 +59,7 @@ module RubyJard
         output.print "\e[0J"
       end
 
-      def disable_cursor!(output = STDOUT)
+      def disable_cursor!(output)
         return unless output.tty?
 
         output.print tput('civis')
@@ -59,7 +68,7 @@ module RubyJard
         output.print "\e[?25l"
       end
 
-      def enable_cursor!(output = STDOUT)
+      def enable_cursor!(output)
         return unless output.tty?
 
         output.print tput('cnorm')
@@ -81,7 +90,7 @@ module RubyJard
         nil
       end
 
-      def raw!(output = STDOUT)
+      def raw!(output)
         return unless output.tty?
 
         begin
@@ -91,7 +100,7 @@ module RubyJard
         end
       end
 
-      def cooked!(output = STDOUT)
+      def cooked!(output)
         return unless output.tty?
 
         begin
@@ -102,7 +111,7 @@ module RubyJard
         end
       end
 
-      def disable_echo!(output = STDOUT)
+      def disable_echo!(output)
         return unless output.tty?
 
         begin
@@ -113,7 +122,7 @@ module RubyJard
         end
       end
 
-      def enable_echo!(output = STDOUT)
+      def enable_echo!(output)
         return unless output.tty?
 
         begin

--- a/lib/ruby_jard/console.rb
+++ b/lib/ruby_jard/console.rb
@@ -15,7 +15,11 @@ module RubyJard
           if STDOUT.tty?
             STDOUT
           else
-            File.open('/dev/tty', 'w+')
+            begin
+              File.open('/dev/tty', 'w+')
+            rescue StandardError
+              STDOUT # Give up now. TODO: should warn, and let program continues
+            end
           end
       end
 
@@ -26,7 +30,11 @@ module RubyJard
           if STDIN.tty?
             STDIN
           else
-            File.open('/dev/tty', 'r+')
+            begin
+              File.open('/dev/tty', 'r+')
+            rescue StandardError
+              STDIN # Give up. TODO: should warn, and let program continues
+            end
           end
       end
 

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -51,8 +51,8 @@ module RubyJard
         # from /dev/tty), in which, the same as RubyJard::Console.output
         # - Otherwise, it writes directly into pry's REPL output.
         # That's why there should be two output here
-        @tty_output = RubyJard::Console.output
-        @window_width, @window_height = RubyJard::Console.screen_size(@tty_output)
+        @tty_output = RubyJard::Console.redirected? ? RubyJard::Console.output : pry_instance.output
+        @window_width, @window_height = RubyJard::Console.screen_size(RubyJard::Console.output)
         @tracker = JardPageTracker.new(@window_height, @window_width)
         @pager = force_open ? open_pager : nil
       end

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -46,7 +46,7 @@ module RubyJard
         @pager_start_at_the_end = pager_start_at_the_end
         @prompt = prompt
 
-        @window_width, @window_height = RubyJard::Console.screen_size(@pry_instance.output)
+        @window_width, @window_height = RubyJard::Console.screen_size(RubyJard::Console.output)
         @tracker = JardPageTracker.new(@window_height, @window_width)
         @pager = force_open ? open_pager : nil
       end

--- a/lib/ruby_jard/pager.rb
+++ b/lib/ruby_jard/pager.rb
@@ -46,7 +46,13 @@ module RubyJard
         @pager_start_at_the_end = pager_start_at_the_end
         @prompt = prompt
 
-        @window_width, @window_height = RubyJard::Console.screen_size(RubyJard::Console.output)
+        # There are two cases:
+        # - If the real pager (less) is triggered, it works on a real tty (fetched
+        # from /dev/tty), in which, the same as RubyJard::Console.output
+        # - Otherwise, it writes directly into pry's REPL output.
+        # That's why there should be two output here
+        @tty_output = RubyJard::Console.output
+        @window_width, @window_height = RubyJard::Console.screen_size(@tty_output)
         @tracker = JardPageTracker.new(@window_height, @window_width)
         @pager = force_open ? open_pager : nil
       end
@@ -93,7 +99,7 @@ module RubyJard
 
         IO.popen(
           less_command.join(' '), 'w',
-          out: @pry_instance.output, err: @pry_instance.output
+          out: @tty_output, err: @tty_output
         )
       end
 

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -30,6 +30,7 @@ module RubyJard
         key_bindings: RubyJard.global_key_bindings
       )
       @previous_flow = RubyJard::ControlFlow.new(:next)
+      @output = RubyJard::Console.output
     end
 
     def at_line
@@ -123,10 +124,10 @@ module RubyJard
       next_frame = find_frame(options[:frame].to_i)
       if next_frame.nil?
         # There must be an error in outer validators
-        RubyJard::ScreenManager.puts 'Error: Frame not found. There should be an error with Jard.'
+        @output.puts 'Error: Frame not found. There should be an error with Jard.'
         process_commands(false)
       elsif next_frame.c_frame?
-        RubyJard::ScreenManager.puts "Error: Frame #{next_frame} is a c-frame. Not able to inspect c layer!"
+        @output.puts "Error: Frame #{next_frame} is a c-frame. Not able to inspect c layer!"
         process_commands(false)
       else
         RubyJard::Session.frame = next_frame.real_pos
@@ -135,7 +136,7 @@ module RubyJard
     end
 
     def handle_continue_command(_options = {})
-      RubyJard::ScreenManager.puts '▸▸ Program resumed ▸▸'
+      @output.puts '▸▸ Program resumed ▸▸'
       Byebug.stop if Byebug.stoppable?
     end
 

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -123,7 +123,10 @@ module RubyJard
       end
     end
 
-    def initialize(key_bindings: nil)
+    def initialize(key_bindings: nil, input: RubyJard::Console.input, output: RubyJard::Console.output)
+      @input = input
+      @output = output
+
       @state = ReplState.new
 
       @pry_input_pipe_read, @pry_input_pipe_write = IO.pipe
@@ -147,8 +150,8 @@ module RubyJard
       @state.ready!
       @openning_pager = false
 
-      RubyJard::Console.disable_echo!
-      RubyJard::Console.raw!
+      RubyJard::Console.disable_echo!(@output)
+      RubyJard::Console.raw!(@output)
 
       Readline.input = @pry_input_pipe_read
       Readline.output = @pry_output_pty_write
@@ -172,10 +175,10 @@ module RubyJard
       sleep PTY_OUTPUT_TIMEOUT until @state.exited?
       RubyJard::ControlFlow.dispatch(e.flow)
     ensure
-      RubyJard::Console.enable_echo!
-      RubyJard::Console.cooked!
-      Readline.input = STDIN
-      Readline.output = STDOUT
+      RubyJard::Console.enable_echo!(@output)
+      RubyJard::Console.cooked!(@output)
+      Readline.input = @input
+      Readline.output = @output
       @key_listen_thread&.exit if @key_listen_thread&.alive?
       @pry_input_thread&.exit if @pry_input_thread&.alive?
       @state.exited!
@@ -184,23 +187,23 @@ module RubyJard
     private
 
     def read_key
-      RubyJard::Console.getch(STDIN, KEY_READ_TIMEOUT)
+      RubyJard::Console.getch(@input, KEY_READ_TIMEOUT)
     end
 
     def pry_pty_output
       loop do
         if @state.exiting?
           if @pry_output_pty_read.ready?
-            STDOUT.write @pry_output_pty_read.read_nonblock(2048), from_jard: true
+            write_output(@pry_output_pty_read.read_nonblock(2048))
           else
             @state.exited!
           end
         elsif @state.exited?
           sleep PTY_OUTPUT_TIMEOUT
         else
-          output = @pry_output_pty_read.read_nonblock(2048)
-          unless output.nil?
-            STDOUT.write output, from_jard: true
+          content = @pry_output_pty_read.read_nonblock(2048)
+          unless content.nil?
+            write_output(content)
           end
         end
       rescue IO::WaitReadable, IO::WaitWritable
@@ -316,25 +319,33 @@ module RubyJard
     def pry_hooks
       hooks = Pry::Hooks.default
       hooks.add_hook(:after_read, :jard_proxy_acquire_lock) do |_read_string, _pry|
-        RubyJard::Console.cooked!
+        RubyJard::Console.cooked!(@output)
         @state.processing!
         # Sleep 2 ticks, wait for pry to print out all existing output in the queue
         sleep PTY_OUTPUT_TIMEOUT * 2
       end
       hooks.add_hook(:after_handle_line, :jard_proxy_release_lock) do
-        RubyJard::Console.raw!
+        RubyJard::Console.raw!(@output)
         @state.ready!
       end
       hooks.add_hook(:before_pager, :jard_proxy_before_pager) do
         @openning_pager = true
 
         @state.processing!
-        RubyJard::Console.cooked!
+        RubyJard::Console.cooked!(@output)
       end
       hooks.add_hook(:after_pager, :jard_proxy_after_pager) do
         @openning_pager = false
         @state.ready!
-        RubyJard::Console.raw!
+        RubyJard::Console.raw!(@output)
+      end
+    end
+
+    def write_output(content)
+      if @output == $stdout
+        @output.write content, from_jard: true
+      else
+        @output.write content
       end
     end
   end

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -348,11 +348,10 @@ module RubyJard
     end
 
     def write_output(content)
-      # TODO: Fix me. This one and stdout overiding in session.rb should be unified
-      if @output == $stdout
-        @output.write content.force_encoding('UTF-8'), from_jard: true
-      else
+      if RubyJard::Console.redirected?
         @output.write content.force_encoding('UTF-8')
+      else
+        @output.write content.force_encoding('UTF-8'), from_jard: true
       end
     end
   end

--- a/lib/ruby_jard/screen_manager.rb
+++ b/lib/ruby_jard/screen_manager.rb
@@ -38,7 +38,7 @@ module RubyJard
 
     attr_reader :output, :output_storage
 
-    def initialize(output: STDOUT)
+    def initialize(output: RubyJard::Console.output)
       @output = output
       @screens = {}
       @started = false
@@ -68,9 +68,9 @@ module RubyJard
 
       @started = false
 
-      RubyJard::Console.cooked!
-      RubyJard::Console.enable_echo!
-      RubyJard::Console.enable_cursor!
+      RubyJard::Console.cooked!(@output)
+      RubyJard::Console.enable_echo!(@output)
+      RubyJard::Console.enable_cursor!(@output)
     end
 
     def draw_screens
@@ -78,7 +78,7 @@ module RubyJard
       @updating = true
 
       RubyJard::Console.clear_screen(@output)
-      RubyJard::Console.disable_cursor!
+      RubyJard::Console.disable_cursor!(@output)
       width, height = RubyJard::Console.screen_size(@output)
 
       @layouts = calculate_layouts(width, height)
@@ -102,9 +102,9 @@ module RubyJard
       draw_error(e, height)
     ensure
       # You don't want to mess up previous user TTY no matter happens
-      RubyJard::Console.cooked!
-      RubyJard::Console.enable_echo!
-      RubyJard::Console.enable_cursor!
+      RubyJard::Console.cooked!(@output)
+      RubyJard::Console.enable_echo!(@output)
+      RubyJard::Console.enable_cursor!(@output)
       @updating = false
     end
 
@@ -126,10 +126,6 @@ module RubyJard
       end
       @output.puts '-------------'
       RubyJard.error(exception)
-    end
-
-    def puts(content)
-      @output.write "#{content}\n", from_jard: true
     end
 
     private

--- a/spec/examples/cli.rb
+++ b/spec/examples/cli.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'ruby_jard'
+
+jard
+puts "What's your name?"
+name = STDIN.gets.strip
+
+puts 'How old are your?'
+age = STDIN.gets.strip.to_i
+
+jard
+puts "Hi, #{name} (#{age})"
+
+jard
+puts 'Nice to meet you'
+
+warn 'Error! Failed to continue'
+jard
+puts 'Exiting'

--- a/spec/examples/placement_8_example.rb
+++ b/spec/examples/placement_8_example.rb
@@ -1,4 +1,4 @@
 require 'ruby_jard'
 
-print print print print print (byebug or 15)
+print print print print print (jard or 15)
 sleep 0

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -53,7 +53,6 @@ class JardIntegrationTest
   def resize(width, height)
     @width = width
     @height = height
-    @resized = true
     tmux(
       'resize-window',
       '-t', @target,
@@ -242,15 +241,12 @@ class JardIntegrationTest
   end
 
   def capture_pane
-    if @resized
-      tmux('capture-pane', '-J', '-p', '-t', @target)
-        .split("\n")
-        .map { |line| line[0..@width - 1] }
-        .first(@height)
-        .join("\n")
-    else
-      tmux('capture-pane', '-J', '-p', '-t', @target)
-    end
+    tmux('capture-pane', '-J', '-p', '-t', @target)
+      .split("\n")
+      .map { |line| line.length > @width ? line.chars.each_slice(@width).map(&:join) : line }
+      .flatten
+      .first(@height)
+      .join("\n")
   end
 end
 

--- a/spec/helpers/integration_helper.rb
+++ b/spec/helpers/integration_helper.rb
@@ -143,8 +143,6 @@ class JardIntegrationTest
 
       attempt -= 1
       sleep 0.5
-
-      puts "\t# Fai to capture pane. Retrying..."
     end
 
     attempt = 5
@@ -156,8 +154,6 @@ class JardIntegrationTest
 
       attempt -= 1
       sleep 0.5
-
-      puts "\t# Pane content seems to be different from previous capture. Retrying..."
     end
     @content
   end

--- a/spec/integration/auto_layout/resize.expected
+++ b/spec/integration/auto_layout/resize.expected
@@ -28,15 +28,25 @@ Resize to 50, 60
 ### START SCREEN ###
 ┌ Source  ../../examples/top_level_example.rb:15 ┐
 │   2                                            │
+│   3 require 'ruby_jard'                        │
 │   4                                            │
+│   5 var_a = 123                                │
 │   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
 │   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
 │   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
 │  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
 │     ror')                                      │
+│  13                                            │
 │  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
 │  16                                            │
+│  17 jard                                       │
 │  18 1.times {}                                 │
+│  19                                            │
 │  20 jard                                       │
 │  21 var_a + variable_f + variable_h || 5       │
 │                                                │
@@ -73,10 +83,15 @@ Resize to 50, 40
 ### END RESIZE ###
 ### START SCREEN ###
 ┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   7 var_c = ['Hello', 1, 2, 3]                 │
 │   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
 │   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
 │  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
 │     ror')                                      │
+│  13                                            │
 │  14 jard                                       │
 │⮕ 15 variable_h = 15                            │
 │  16                                            │
@@ -164,14 +179,23 @@ Resize to 100, 50
 ### END RESIZE ###
 ### START SCREEN ###
 ┌ Source  ../../examples/top_level_example.rb:15 ──────────────────────────────────────────────────┐
+│   6 var_b = 'hello world'                                                                        │
 │   7 var_c = ['Hello', 1, 2, 3]                                                                   │
+│   8 variable_d = { test: 1, this: 'Bye', array: nil }                                            │
 │   9 variable_e = /Wait, what/i                                                                   │
+│  10 variable_f = 1.1                                                                             │
 │  11 variable_g = 99..100                                                                         │
+│  12 variable_k = StandardError.new('A random error')                                             │
 │  13                                                                                              │
+│  14 jard                                                                                         │
 │⮕ 15 variable_h = 15                                                                              │
+│  16                                                                                              │
 │  17 jard                                                                                         │
+│  18 1.times {}                                                                                   │
 │  19                                                                                              │
+│  20 jard                                                                                         │
 │  21 var_a + variable_f + variable_h || 5                                                         │
+│                                                                                                  │
 │                                                                                                  │
 ├ Variables ───────────────────────────────────────────────────────────────────────────────────────┤
 │  self = main                                                                                     │
@@ -203,14 +227,23 @@ Resize to 140, 70
 ### END RESIZE ###
 ### START SCREEN ###
 ┌ Source  ../../examples/top_level_example.rb:15 ────────────────────┬ Variables ──────────────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                                  │  self = main                                                        │
 │   2                                                                │  var_a = 123                                                        │
+│   3 require 'ruby_jard'                                            │  var_b = "hello world"                                              │
 │   4                                                                │▾ var_c (len:4) = [                                                  │
+│   5 var_a = 123                                                    │    ▸ "Hello"                                                        │
 │   6 var_b = 'hello world'                                          │    ▸ 1                                                              │
+│   7 var_c = ['Hello', 1, 2, 3]                                     │    ▸ 2                                                              │
 │   8 variable_d = { test: 1, this: 'Bye', array: nil }              │    ▸ 3                                                              │
+│   9 variable_e = /Wait, what/i                                     │  ]                                                                  │
 │  10 variable_f = 1.1                                               │  variable_d (size:3) = {:test → 1, :this → "Bye", :array → nil}     │
+│  11 variable_g = 99..100                                           │  variable_e = /Wait, what/i                                         │
 │  12 variable_k = StandardError.new('A random error')               │  variable_f = 1.1                                                   │
+│  13                                                                │  variable_g = 99..100                                               │
 │  14 jard                                                           │  variable_h = nil                                                   │
+│⮕ 15 variable_h = 15                                                │  variable_k = #<StandardError: A random error>                      │
 │  16                                                                │                                                                     │
+│  17 jard                                                           │                                                                     │
 │  18 1.times {}                                                     │                                                                     │
 │  19                                                                │                                                                     │
 │  20 jard                                                           │                                                                     │

--- a/spec/integration/commands/scheme.switch_not_found.expected
+++ b/spec/integration/commands/scheme.switch_not_found.expected
@@ -30,7 +30,8 @@ jard >>
 ### START SCREEN ###
 
 jard >> jard color-scheme NotExistedScheme
-Error: Color scheme `NotExistedScheme` not found. Please use `jard color-scheme -l` to list all color schemes.
+Error: Color scheme `NotExistedScheme` not found. Please use `jard color-scheme
+-l` to list all color schemes.
 jard >>
 
 

--- a/spec/integration/placements/placement_8.expected
+++ b/spec/integration/placements/placement_8.expected
@@ -1,26 +1,24 @@
 ### START SCREEN ###
-15
-[1, 4] in ???????????????????????????????????????????????????????????????????????????????????????????????
-   1: require 'ruby_jard'
-   2:
-   3: print print print print print (byebug or 15)
-=> 4: sleep 0
-(byebug)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+┌ Source  ../../examples/placement_8_example.rb:4 ─────────────────────────────┐
+│   1 require 'ruby_jard'                                                      │
+│   2                                                                          │
+│   3 print print print print print (jard or 15)                               │
+│⮕  4 sleep 0                                                                  │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application -../../examples/top_level_example.rb   Step (F7)    »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
 ### END SCREEN ###

--- a/spec/integration/placements/placement_spec.rb
+++ b/spec/integration/placements/placement_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Load config file from ENV', integration: true do
+RSpec.describe 'Test different placement positions', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/placements') }
 
   context 'when calling jard next to jard' do
@@ -11,6 +11,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -23,6 +24,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -35,6 +37,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -49,6 +52,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.assert_screen
       test.send_keys('next', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -63,6 +67,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.assert_screen
       test.send_keys('step', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -75,6 +80,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -87,6 +93,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -99,6 +106,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       )
       test.start
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -115,6 +123,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.assert_screen
       test.send_keys('continue', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -130,6 +139,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.send_keys('require_relative "../../examples/top_level_example.rb"', :Enter)
       test.send_keys('system("clear")', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -144,6 +154,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.assert_screen
       test.send_keys('require_relative "../../examples/instance_method_example.rb"', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end
@@ -164,6 +175,7 @@ RSpec.describe 'Load config file from ENV', integration: true do
       test.assert_screen
       test.send_keys('continue', :Enter)
       test.assert_screen
+    ensure
       test.stop
     end
   end

--- a/spec/integration/standard_streams/normal.expected
+++ b/spec/integration/standard_streams/normal.expected
@@ -1,0 +1,228 @@
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:6 ─────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = nil                                                 │
+│   3 require 'ruby_jard'                                  │  name = nil                                                │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│⮕  6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:6           │▸ Thread 1 (run) untitled at ../../examples/cli.rb:6        │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["Quang-Minh", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["17", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:13 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = 17                                                  │
+│   3 require 'ruby_jard'                                  │  name = "Quang-Minh"                                       │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│⮕ 13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:13          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:13       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:16 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   3 require 'ruby_jard'                                  │  self = main                                               │
+│   4                                                      │  age = 17                                                  │
+│   5 jard                                                 │  name = "Quang-Minh"                                       │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│⮕ 16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:16          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:16       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:20 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   7 name = STDIN.gets.strip                              │  self = main                                               │
+│   8                                                      │  age = 17                                                  │
+│   9 puts 'How old are your?'                             │  name = "Quang-Minh"                                       │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│⮕ 20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:20          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:20       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["jard output", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+▸▸ Program resumed ▸▸         
+What's your name?             
+How old are your?             
+▸▸ Program resumed ▸▸         
+Hi, Quang-Minh (17)           
+▸▸ Program resumed ▸▸         
+Nice to meet you              
+Program output                
+### END SCREEN ###

--- a/spec/integration/standard_streams/pipe_both_stdin_stdout.expected
+++ b/spec/integration/standard_streams/pipe_both_stdin_stdout.expected
@@ -1,0 +1,225 @@
+### START SEND_KEYS ###
+["echo \"Not Minh\n19\n\" | bundle exec ruby /home/darkwing0711/www/ruby_jard/spec/examples/cli.rb | cat", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:6 ─────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = nil                                                 │
+│   3 require 'ruby_jard'                                  │  name = nil                                                │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│⮕  6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:6           │▸ Thread 1 (run) untitled at ../../examples/cli.rb:6        │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:13 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = 19                                                  │
+│   3 require 'ruby_jard'                                  │  name = "Not Minh"                                         │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│⮕ 13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:13          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:13       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:16 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   3 require 'ruby_jard'                                  │  self = main                                               │
+│   4                                                      │  age = 19                                                  │
+│   5 jard                                                 │  name = "Not Minh"                                         │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│⮕ 16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:16          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:16       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:20 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   7 name = STDIN.gets.strip                              │  self = main                                               │
+│   8                                                      │  age = 19                                                  │
+│   9 puts 'How old are your?'                             │  name = "Not Minh"                                         │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│⮕ 20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:20          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:20       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["jard output", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+What's your name?             
+How old are your?             
+Hi, Not Minh (19)             
+Nice to meet you              
+Program output                
+### END SCREEN ###

--- a/spec/integration/standard_streams/pipe_stdin.expected
+++ b/spec/integration/standard_streams/pipe_stdin.expected
@@ -1,0 +1,205 @@
+### START SEND_KEYS ###
+["echo \"Not Minh\n19\n\" | bundle exec ruby /home/darkwing0711/www/ruby_jard/spec/examples/cli.rb", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:6 ─────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = nil                                                 │
+│   3 require 'ruby_jard'                                  │  name = nil                                                │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│⮕  6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:6           │▸ Thread 1 (run) untitled at ../../examples/cli.rb:6        │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:13 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = 19                                                  │
+│   3 require 'ruby_jard'                                  │  name = "Not Minh"                                         │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│⮕ 13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:13          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:13       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:16 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   3 require 'ruby_jard'                                  │  self = main                                               │
+│   4                                                      │  age = 19                                                  │
+│   5 jard                                                 │  name = "Not Minh"                                         │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│⮕ 16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:16          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:16       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:20 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   7 name = STDIN.gets.strip                              │  self = main                                               │
+│   8                                                      │  age = 19                                                  │
+│   9 puts 'How old are your?'                             │  name = "Not Minh"                                         │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│⮕ 20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:20          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:20       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+### END SCREEN ###
+### START SEND_KEYS ###
+["jard output", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+▸▸ Program resumed ▸▸
+What's your name?
+How old are your?
+▸▸ Program resumed ▸▸
+Hi, Not Minh (19)
+▸▸ Program resumed ▸▸
+Nice to meet you
+Program output
+### END SCREEN ###

--- a/spec/integration/standard_streams/pipe_stdout.expected
+++ b/spec/integration/standard_streams/pipe_stdout.expected
@@ -1,0 +1,231 @@
+### START SEND_KEYS ###
+["bundle exec ruby /home/darkwing0711/www/ruby_jard/spec/examples/cli.rb | cat", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:6 ─────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = nil                                                 │
+│   3 require 'ruby_jard'                                  │  name = nil                                                │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│⮕  6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:6           │▸ Thread 1 (run) untitled at ../../examples/cli.rb:6        │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["Quang-Minh", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["17", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:13 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = 17                                                  │
+│   3 require 'ruby_jard'                                  │  name = "Quang-Minh"                                       │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│⮕ 13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:13          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:13       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:16 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   3 require 'ruby_jard'                                  │  self = main                                               │
+│   4                                                      │  age = 17                                                  │
+│   5 jard                                                 │  name = "Quang-Minh"                                       │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│⮕ 16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:16          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:16       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:20 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   7 name = STDIN.gets.strip                              │  self = main                                               │
+│   8                                                      │  age = 17                                                  │
+│   9 puts 'How old are your?'                             │  name = "Quang-Minh"                                       │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│⮕ 20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:20          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:20       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>
+
+
+
+
+
+### END SCREEN ###
+### START SEND_KEYS ###
+["jard output", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+~
+What's your name?
+How old are your?
+Hi, Quang-Minh (17)
+Nice to meet you
+Program output
+### END SCREEN ###

--- a/spec/integration/standard_streams/redirect_stdout.expected
+++ b/spec/integration/standard_streams/redirect_stdout.expected
@@ -1,0 +1,211 @@
+### START SEND_KEYS ###
+["bundle exec ruby /home/darkwing0711/www/ruby_jard/spec/examples/cli.rb > /dev/null", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:6 ─────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = nil                                                 │
+│   3 require 'ruby_jard'                                  │  name = nil                                                │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│⮕  6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:6           │▸ Thread 1 (run) untitled at ../../examples/cli.rb:6        │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["Quang-Minh", :Enter]
+### END SEND_KEYS ###
+### START SEND_KEYS ###
+["17", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:13 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   1 # frozen_string_literal: true                        │  self = main                                               │
+│   2                                                      │  age = 17                                                  │
+│   3 require 'ruby_jard'                                  │  name = "Quang-Minh"                                       │
+│   4                                                      │                                                            │
+│   5 jard                                                 │                                                            │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│⮕ 13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:13          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:13       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:16 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   3 require 'ruby_jard'                                  │  self = main                                               │
+│   4                                                      │  age = 17                                                  │
+│   5 jard                                                 │  name = "Quang-Minh"                                       │
+│   6 puts "What's your name?"                             │                                                            │
+│   7 name = STDIN.gets.strip                              │                                                            │
+│   8                                                      │                                                            │
+│   9 puts 'How old are your?'                             │                                                            │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│⮕ 16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│  20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:16          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:16       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+### END SCREEN ###
+### START SEND_KEYS ###
+["continue", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/cli.rb:20 ────────────────────────┬ Variables ─────────────────────────────────────────────────┐
+│   7 name = STDIN.gets.strip                              │  self = main                                               │
+│   8                                                      │  age = 17                                                  │
+│   9 puts 'How old are your?'                             │  name = "Quang-Minh"                                       │
+│  10 age = STDIN.gets.strip.to_i                          │                                                            │
+│  11                                                      │                                                            │
+│  12 jard                                                 │                                                            │
+│  13 puts "Hi, #{name} (#{age})"                          │                                                            │
+│  14                                                      │                                                            │
+│  15 jard                                                 │                                                            │
+│  16 puts 'Nice to meet you'                              │                                                            │
+│  17                                                      │                                                            │
+│  18 warn 'Error! Failed to continue'                     │                                                            │
+│  19 jard                                                 │                                                            │
+│⮕ 20 puts 'Exiting'                                       │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├ Backtrace  1 frames ─────────────────────────────────────┼ Threads  1 threads ────────────────────────────────────────┤
+│⮕ 0 Object in <main> at ../../examples/cli.rb:20          │▸ Thread 1 (run) untitled at ../../examples/cli.rb:20       │
+│                                                          │                                                            │
+│                                                          │                                                            │
+├──────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┤
+│Filter (F2): Application                                    Step (F7)   Step Out (Shift+F7)   Next (F8)   Continue (F9)│
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+jard >>                       
+### END SCREEN ###
+### START SEND_KEYS ###
+["jard output", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+~                             
+What's your name?             
+How old are your?             
+Hi, Quang-Minh (17)           
+Nice to meet you              
+Program output                
+### END SCREEN ###

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Test standard_streams', integration: true do
+  let(:work_dir) { File.join(RSPEC_ROOT, '/integration/standard_streams') }
+
+  context 'when nothing are redirected' do
+    it 'works normally' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'normal.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb",
+        width: 121, height: 40
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.send_keys('Quang-Minh', :Enter)
+      test.send_keys('17', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when pipe the stdin' do
+    it 'works normally' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'pipe_stdin.expected', 'bash',
+        width: 121, height: 40
+      )
+
+      test.start
+      test.send_keys("echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb", :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when pipe the stdout' do
+    it 'works normally' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'pipe_stdout.expected', 'bash',
+        width: 121, height: 40
+      )
+
+      test.start
+      test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null", :Enter)
+      sleep 1
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.send_keys('Quang-Minh', :Enter)
+      test.send_keys('17', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when pipe both stdin and stdout' do
+    it 'works normally' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'pipe_both_stdin_stdout.expected', 'bash',
+        width: 121, height: 40
+      )
+
+      test.start
+      test.send_keys(
+        "echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null",
+        :Enter
+      )
+      sleep 1
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when redirect stdout' do
+    it 'works normally' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'redirect_stdout.expected', 'bash',
+        width: 121, height: 40
+      )
+
+      test.start
+      test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb > /dev/null", :Enter)
+      sleep 1
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.send_keys('Quang-Minh', :Enter)
+      test.send_keys('17', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.assert_screen
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+end

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Test standard_streams', integration: true do
+  let(:shell) do
+    shell = `echo $SHELL`.strip
+    shell.empty? ? 'zsh' : shell
+  end
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/standard_streams') }
 
   context 'when nothing are redirected' do
@@ -30,7 +34,7 @@ RSpec.describe 'Test standard_streams', integration: true do
   context 'when pipe the stdin' do
     it 'works normally' do
       test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_stdin.expected', 'bash',
+        self, work_dir, 'pipe_stdin.expected', shell,
         width: 121, height: 40
       )
 
@@ -53,7 +57,7 @@ RSpec.describe 'Test standard_streams', integration: true do
   context 'when pipe the stdout' do
     it 'works normally' do
       test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_stdout.expected', 'bash',
+        self, work_dir, 'pipe_stdout.expected', shell,
         width: 121, height: 40
       )
 
@@ -79,7 +83,7 @@ RSpec.describe 'Test standard_streams', integration: true do
   context 'when pipe both stdin and stdout' do
     it 'works normally' do
       test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_both_stdin_stdout.expected', 'bash',
+        self, work_dir, 'pipe_both_stdin_stdout.expected', shell,
         width: 121, height: 40
       )
 
@@ -106,7 +110,7 @@ RSpec.describe 'Test standard_streams', integration: true do
   context 'when redirect stdout' do
     it 'works normally' do
       test = JardIntegrationTest.new(
-        self, work_dir, 'redirect_stdout.expected', 'bash',
+        self, work_dir, 'redirect_stdout.expected', shell,
         width: 121, height: 40
       )
 

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe 'Test standard_streams', integration: true do
   let(:shell) do
-    shell = `echo $SHELL`.strip
-    shell.empty? ? 'zsh' : shell
+    shell = `which zsh`.strip
+    shell.empty? ? `echo $SHELL` : 'zsh'
   end
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/standard_streams') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,9 +22,6 @@ require_relative_folder('./helpers/**/*')
 require_relative_folder('./shared/**/*')
 
 RSpec.configure do |config|
-  config.verbose_retry = true
-  config.display_try_failure_messages = true
-
   config.around :each, :integration do |ex|
     ex.run_with_retry retry: 3
   end


### PR DESCRIPTION
There are some issues that mention Jard doesn't work well with foreman, pumactl, and similar apps redirect the standard stream. In addition, it doesn't work well with piping as well. This PR is to handle such cases by detecting real user's tty in case STDIN/STDOUT are not tty. 

[![asciicast](https://asciinema.org/a/vMgIp2GksU4oqAJFagyznDicn.svg)](https://asciinema.org/a/vMgIp2GksU4oqAJFagyznDicn)

Some tested and covered in tests:
- Pipe stdin and stdout (covered in tests)
- Redirect stdin and stdout (covered in tests)
- Foreman (tested manually)

TODO in later PRs:
- What if Jard runs inside docker?
- What if Jard starts in an isolated process group, and doesn't have TTY at all?

Related issues: 
- https://github.com/nguyenquangminh0711/ruby_jard/issues/46
- https://github.com/nguyenquangminh0711/ruby_jard/issues/38