### PR TITLE
Fix slowness after exit

### DIFF
--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -141,6 +141,7 @@ module RubyJard
     end
 
     def handle_exit_command(_options = {})
+      Byebug.stop if Byebug.stoppable?
       Kernel.exit
     end
 

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -216,6 +216,10 @@ module RubyJard
         # Retry
         sleep PTY_OUTPUT_TIMEOUT
       end
+    rescue StandardError
+      # This thread shoud never die, or the user may be freezed, and cannot type anything
+      sleep 0.5
+      retry
     end
 
     def pry_repl(current_binding)


### PR DESCRIPTION
After user types exit, Jard calls `Kernel.exit`. However, if the process captures thread exit event, and recover, Jard (actualy byebug) still has a hook in tracepoint API. That slows down everything later, even if the process never steps into a debugging section again.

This fixes https://github.com/nguyenquangminh0711/ruby_jard/issues/49