### PR TITLE
Use setsid to test controlling terminal detachment

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -60,6 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7.1, head]
+    env:
+      CI_PLATFORM: "macos"
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -69,8 +71,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: brew install tmux
-    - name: Install setsid
-      run: brew install util-linux
     - name: Start tmux
       run: tmux start-server
     - name: start dummy tmux session

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -69,6 +69,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Install tmux
       run: brew install tmux
+    - name: Install setsid
+      run: brew install util-linux
     - name: Start tmux
       run: tmux start-server
     - name: start dummy tmux session

--- a/spec/examples/detach_example.rb
+++ b/spec/examples/detach_example.rb
@@ -1,0 +1,20 @@
+def detach
+  reader, writer = IO.pipe
+
+  pid = Kernel.spawn(
+    "setsid bundle exec ruby #{File.join(File.dirname(__FILE__), 'top_level_example.rb')}",
+    out: writer, err: writer, pgroup: true, close_others: true
+  )
+  Process.detach(pid)
+  until reader.eof? || writer.closed?
+    content = reader.read_nonblock(2048) rescue nil
+    if content.nil?
+      sleep 1.to_f / 30
+    else
+      STDOUT.write content
+    end
+  end
+ensure
+  Process.kill('SIGTERM', pid)
+end
+detach

--- a/spec/integration/standard_streams/detached.expected
+++ b/spec/integration/standard_streams/detached.expected
@@ -1,0 +1,14 @@
+### START SCREEN ###
+Failed to attach. Jard could not detect a valid tty device. 
+This bug occurs when the process Jard trying to access is a non-interactive environment  such as docker, daemon, sub-proc
+esses, etc.                   
+If you are confused, please submit an issue in https://github.com/nguyenquangminh0711/ruby_jard/issues.                  
+Failed to attach. Jard could not detect a valid tty device. 
+This bug occurs when the process Jard trying to access is a non-interactive environment  such as docker, daemon, sub-proc
+esses, etc.                   
+If you are confused, please submit an issue in https://github.com/nguyenquangminh0711/ruby_jard/issues.                  
+Failed to attach. Jard could not detect a valid tty device. 
+This bug occurs when the process Jard trying to access is a non-interactive environment  such as docker, daemon, sub-proc
+esses, etc.                   
+If you are confused, please submit an issue in https://github.com/nguyenquangminh0711/ruby_jard/issues.                  
+### END SCREEN ###

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -132,4 +132,18 @@ RSpec.describe 'Test standard_streams', integration: true do
       test.stop
     end
   end
+
+  context 'when a process has controlling terminal detached' do
+    it 'refused to attach' do
+      test = JardIntegrationTest.new(
+        self, work_dir, 'detached.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/detach_example.rb",
+        width: 121, height: 40
+      )
+      test.start
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
 end

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -133,17 +133,19 @@ RSpec.describe 'Test standard_streams', integration: true do
     end
   end
 
-  context 'when a process has controlling terminal detached' do
-    it 'refused to attach' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'detached.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/detach_example.rb",
-        width: 121, height: 40
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+  if ENV['CI'].nil? || ENV['CI_PLATFORM'] != 'macos'
+    context 'when a process has controlling terminal detached' do
+      it 'refused to attach' do
+        test = JardIntegrationTest.new(
+          self, work_dir, 'detached.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/detach_example.rb",
+          width: 121, height: 40
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end


### PR DESCRIPTION
In previous PRs, Jard refused to start when the current controlling terminal is not valid, but there is no tests to cover that use case. This PR is to add a simple test using setsid.