### PR TITLE
Improve filter performance

### DIFF
--- a/lib/ruby_jard/commands/filter_command.rb
+++ b/lib/ruby_jard/commands/filter_command.rb
@@ -70,11 +70,14 @@ module RubyJard
                 "Please type `#{highlight('jard filter --help')}` for more information"
         end
         filters = args.map(&:strip)
-        @config.filter_included.append(*filters)
-        @config.filter_included.uniq!
+        included = @config.filter_included.dup.append(*filters).uniq
+        excluded = @config.filter_excluded.dup
         filters.each do |filter|
-          @config.filter_excluded.delete(filter) if @config.filter_excluded.include?(filter)
+          excluded.delete(filter) if excluded.include?(filter)
         end
+
+        @config.filter_included = included
+        @config.filter_excluded = excluded
         RubyJard::ControlFlow.dispatch(:list)
       end
 
@@ -85,17 +88,22 @@ module RubyJard
                 "Please type `#{highlight('jard filter --help')}` for more information"
         end
         filters = args.map(&:strip)
-        @config.filter_excluded.append(*filters)
-        @config.filter_excluded.uniq!
+
+        included = @config.filter_included.dup
+        excluded = @config.filter_excluded.dup.append(*filters).uniq
+
         filters.each do |filter|
-          @config.filter_included.delete(filter) if @config.filter_included.include?(filter)
+          included.delete(filter) if included.include?(filter)
         end
+
+        @config.filter_included = included
+        @config.filter_excluded = excluded
         RubyJard::ControlFlow.dispatch(:list)
       end
 
       def handle_clear
-        @config.filter_excluded.clear
-        @config.filter_included.clear
+        @config.filter_excluded = []
+        @config.filter_included = []
         RubyJard::ControlFlow.dispatch(:list)
       end
     end

--- a/lib/ruby_jard/commands/hide_command.rb
+++ b/lib/ruby_jard/commands/hide_command.rb
@@ -30,7 +30,7 @@ module RubyJard
                 "Screen `#{screen}` not found. Please input one of the following: #{@screens.names.join(', ')}"
         end
 
-        @config.enabled_screens.delete(screen)
+        @config.enabled_screens = @config.enabled_screens.dup.delete(screen)
 
         RubyJard::ControlFlow.dispatch(:list)
       end

--- a/lib/ruby_jard/commands/hide_command.rb
+++ b/lib/ruby_jard/commands/hide_command.rb
@@ -30,7 +30,10 @@ module RubyJard
                 "Screen `#{screen}` not found. Please input one of the following: #{@screens.names.join(', ')}"
         end
 
-        @config.enabled_screens = @config.enabled_screens.dup.delete(screen)
+        new_enabled_screens = @config.enabled_screens.dup
+        new_enabled_screens.delete(screen)
+        new_enabled_screens.uniq!
+        @config.enabled_screens = new_enabled_screens
 
         RubyJard::ControlFlow.dispatch(:list)
       end

--- a/lib/ruby_jard/commands/show_command.rb
+++ b/lib/ruby_jard/commands/show_command.rb
@@ -30,8 +30,7 @@ module RubyJard
                 "Screen `#{screen}` not found. Please input one of the following: #{@screens.names.join(', ')}"
         end
 
-        @config.enabled_screens << screen
-        @config.enabled_screens.uniq!
+        @config.enabled_screens = @config.enabled_screens.dup.append(screen)
 
         RubyJard::ControlFlow.dispatch(:list)
       end

--- a/lib/ruby_jard/commands/show_command.rb
+++ b/lib/ruby_jard/commands/show_command.rb
@@ -30,7 +30,10 @@ module RubyJard
                 "Screen `#{screen}` not found. Please input one of the following: #{@screens.names.join(', ')}"
         end
 
-        @config.enabled_screens = @config.enabled_screens.dup.append(screen)
+        new_enabled_screens = @config.enabled_screens.dup
+        new_enabled_screens << screen
+        new_enabled_screens.uniq!
+        @config.enabled_screens = new_enabled_screens
 
         RubyJard::ControlFlow.dispatch(:list)
       end

--- a/lib/ruby_jard/config.rb
+++ b/lib/ruby_jard/config.rb
@@ -38,8 +38,8 @@ module RubyJard
       end
     end
 
-    attr_accessor :color_scheme, :alias_to_debugger, :layout, :enabled_screens
-    attr_reader :filter, :filter_included, :filter_excluded
+    attr_accessor :color_scheme, :alias_to_debugger, :layout
+    attr_reader :enabled_screens, :filter_version, :filter, :filter_included, :filter_excluded
 
     CONFIG_FILE_NAME = '.jardrc'
     DEFAULTS = [
@@ -52,28 +52,38 @@ module RubyJard
     ].freeze
 
     def initialize
-      @color_scheme = DEFAULT_COLOR_SCHEME
-      @alias_to_debugger = DEFAULT_ALIAS_TO_DEBUGGER
-      @layout = DEFAULT_LAYOUT
-      @enabled_screens = RubyJard::Screens.names
+      @filter_version = 0
+
       @filter = DEFAULT_FILTER
       @filter_included = DEFAULT_FILTER_INCLUDED.dup.freeze
       @filter_excluded = DEFAULT_FILTER_EXCLUDED.dup.freeze
+
+      @color_scheme = DEFAULT_COLOR_SCHEME.freeze
+      @alias_to_debugger = DEFAULT_ALIAS_TO_DEBUGGER.freeze
+      @layout = DEFAULT_LAYOUT.freeze
+      @enabled_screens = RubyJard::Screens.names.dup.freeze
     end
 
     def config
       self
     end
 
+    def enabled_screens=(input)
+      @enabled_screens = input.freeze
+    end
+
     def filter=(input)
+      @filter_version += 1
       @filter = input.freeze
     end
 
     def filter_excluded=(input)
+      @filter_version += 1
       @filter_excluded = input.freeze
     end
 
     def filter_included=(input)
+      @filter_version += 1
       @filter_included = input.freeze
     end
   end

--- a/lib/ruby_jard/config.rb
+++ b/lib/ruby_jard/config.rb
@@ -38,8 +38,8 @@ module RubyJard
       end
     end
 
-    attr_accessor :color_scheme, :alias_to_debugger, :layout, :enabled_screens,
-                  :filter, :filter_included, :filter_excluded
+    attr_accessor :color_scheme, :alias_to_debugger, :layout, :enabled_screens
+    attr_reader :filter, :filter_included, :filter_excluded
 
     CONFIG_FILE_NAME = '.jardrc'
     DEFAULTS = [
@@ -57,12 +57,24 @@ module RubyJard
       @layout = DEFAULT_LAYOUT
       @enabled_screens = RubyJard::Screens.names
       @filter = DEFAULT_FILTER
-      @filter_included = DEFAULT_FILTER_INCLUDED.dup
-      @filter_excluded = DEFAULT_FILTER_EXCLUDED.dup
+      @filter_included = DEFAULT_FILTER_INCLUDED.dup.freeze
+      @filter_excluded = DEFAULT_FILTER_EXCLUDED.dup.freeze
     end
 
     def config
       self
+    end
+
+    def filter=(input)
+      @filter = input.freeze
+    end
+
+    def filter_excluded=(input)
+      @filter_excluded = input.freeze
+    end
+
+    def filter_included=(input)
+      @filter_included = input.freeze
     end
   end
 end

--- a/lib/ruby_jard/path_filter.rb
+++ b/lib/ruby_jard/path_filter.rb
@@ -12,22 +12,34 @@ module RubyJard
       FILTER_GEMS = :gems,
       FILTER_EVERYTHING = :everything
     ].freeze
+    attr_reader :cache
+
     def initialize(config: nil, path_classifier: nil)
       @config = config || RubyJard.config
       @path_classifier = path_classifier || RubyJard::PathClassifier.new
+
+      @cache = {}
+      @cache_version = @config.filter_version
     end
 
     def match?(path)
-      case @config.filter
-      when FILTER_EVERYTHING
-        match_everything?(path)
-      when FILTER_GEMS
-        match_gems?(path)
-      when FILTER_APPLICATION
-        match_application?(path)
-      when FILTER_SOURCE_TREE
-        match_source_tree?(path)
+      if @cache_version != @config.filter_version
+        @cache = {}
+        @cache_version = @config.filter_version
       end
+      return @cache[path] unless @cache[path].nil?
+
+      @cache[path] =
+        case @config.filter
+        when FILTER_EVERYTHING
+          match_everything?(path)
+        when FILTER_GEMS
+          match_gems?(path)
+        when FILTER_APPLICATION
+          match_application?(path)
+        when FILTER_SOURCE_TREE
+          match_source_tree?(path)
+        end
     end
 
     private

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -25,7 +25,20 @@ module RubyJard
   # repl, and triggers Byebug debugger if needed.
   #
   class ReplProcessor < Byebug::CommandProcessor
-    REPEATED_FLOW_THRESHOLD = 20_000
+    # NOTE: This is an experimental feature. If the flow is repeated too much,
+    # the debugger refuses to continue, and step out instead.
+    # Why?
+    # Filtering feature is a killing feature of Jard, but it is not affective,
+    # especially with step command. Other commands, such as next, run fast
+    # enough to get up to the frame it should stop. However, step leads the whole
+    # program down to the rabbit hole. The situation gets worse if a method call
+    # triggers Ruby autoload, leads to millions of repeated flows until the program
+    # gets out. In a simple benchmark, it takes minutes to finish. Therefore, as
+    # soon Jard repeats up to a threashold, it should give up, and step out to let
+    # the program continues. The correctness of the debugger is not affected, while
+    # this approach brings better experience. In worst cases, I can recommend the users
+    # to put a breakpoint manually instead.
+    REPEATED_FLOW_THRESHOLD = 5_000
 
     def initialize(context, *args)
       super(context, *args)

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -53,7 +53,7 @@ module RubyJard
       allowing_other_threads do
         RubyJard::Session.lock do
           RubyJard::Session.sync(@context)
-          unless RubyJard::Session.should_stop?
+          unless RubyJard::Session.should_stop?(@context.frame.file)
             handle_flow(@previous_flow)
             return
           end

--- a/lib/ruby_jard/repl_processor.rb
+++ b/lib/ruby_jard/repl_processor.rb
@@ -38,7 +38,7 @@ module RubyJard
     # the program continues. The correctness of the debugger is not affected, while
     # this approach brings better experience. In worst cases, I can recommend the users
     # to put a breakpoint manually instead.
-    REPEATED_FLOW_THRESHOLD = 5_000
+    REPEATED_FLOW_THRESHOLD = 20_000
 
     def initialize(context, *args)
       super(context, *args)

--- a/lib/ruby_jard/session.rb
+++ b/lib/ruby_jard/session.rb
@@ -41,7 +41,7 @@ module RubyJard
 
     OUTPUT_BUFFER_LENGTH = 10_000 # 10k lines
 
-    attr_accessor :output_buffer
+    attr_accessor :output_buffer, :path_filter
 
     def initialize(options = {})
       @options = options
@@ -110,8 +110,8 @@ module RubyJard
       @started == true
     end
 
-    def should_stop?
-      @path_filter.match?(@current_context.frame_file)
+    def should_stop?(path)
+      @path_filter.match?(path)
     end
 
     def sync(context)

--- a/spec/ruby_jard/config_spec.rb
+++ b/spec/ruby_jard/config_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyJard::Config do
+  subject(:config) { described_class.new }
+
+  it 'initializes default configurations' do
+    expect(config.filter_version).to eq(0)
+    expect(config.filter).to eq(:application)
+    expect(config.filter_included).to eq([])
+    expect(config.filter_excluded).to eq([])
+
+    expect(config.color_scheme).to eq('256')
+    expect(config.alias_to_debugger).to eq(false)
+    expect(config.layout).to eq(nil)
+    expect(config.enabled_screens).to match_array(
+      %w[source variables backtrace threads menu]
+    )
+  end
+
+  it 'freezes nested data structure' do
+    expect do
+      config.filter_included.append(123)
+    end.to raise_error(FrozenError)
+    expect do
+      config.filter_excluded.append(123)
+    end.to raise_error(FrozenError)
+    expect do
+      config.enabled_screens.append(123)
+    end.to raise_error(FrozenError)
+  end
+
+  describe '#filter=' do
+    it 'updates filter' do
+      expect { config.filter = :gems }.to change(config, :filter).from(:application).to(:gems)
+    end
+
+    it 'increases filter_version' do
+      expect { config.filter = :gems }.to change(config, :filter_version).from(0).to(1)
+    end
+  end
+
+  describe '#filter_included=' do
+    it 'updates filter_included' do
+      expect { config.filter_included = ['rails'] }.to change(config, :filter_included).from([]).to(['rails'])
+    end
+
+    it 'increases filter_version' do
+      expect { config.filter_included = ['rails'] }.to change(config, :filter_version).from(0).to(1)
+    end
+
+    it 'freezes filter_included afterward' do
+      config.filter_included = ['rails']
+      expect do
+        config.filter_included.append(123)
+      end.to raise_error(FrozenError)
+    end
+  end
+
+  describe '#filter_excluded=' do
+    it 'updates filter_excluded' do
+      expect { config.filter_excluded = ['rails'] }.to change(config, :filter_excluded).from([]).to(['rails'])
+    end
+
+    it 'increases filter_version' do
+      expect { config.filter_excluded = ['rails'] }.to change(config, :filter_version).from(0).to(1)
+    end
+
+    it 'freezes filter_excluded afterward' do
+      config.filter_excluded = ['rails']
+      expect do
+        config.filter_excluded.append(123)
+      end.to raise_error(FrozenError)
+    end
+  end
+
+  describe '#enabled_screens=' do
+    it 'updates enabled_screens' do
+      expect { config.enabled_screens = ['source'] }.to change(config, :enabled_screens).to(['source'])
+    end
+
+    it 'freezes filter_excluded afterward' do
+      config.enabled_screens = ['source']
+      expect do
+        config.enabled_screens.append(123)
+      end.to raise_error(FrozenError)
+    end
+  end
+end


### PR DESCRIPTION
- Freeze all configurations after assignment
- Cache path filter
- If the flow is repeated too much, the debugger refuses to continue, and step out instead. Why? Filtering feature is a killing feature of Jard, but it is not affective, especially with step command. Other commands, such as next, run fast enough to get up to the frame it should stop. However, step leads the whole program down to the rabbit hole. The situation gets worse if a method call triggers Ruby autoload, leads to millions of repeated flows until the program gets out. In a simple benchmark, it takes minutes to finish. Therefore, as soon Jard repeats up to a threashold, it should give up, and step out to let the program continues. The correctness of the debugger is not affected, while this approach brings better experience. In worst cases, I can recommend the users to put a breakpoint manually instead. The current time threshold is 5 seconds, and repeated count is 20_000 times

Tested with an extreme example: `Faker::Movie.title`. When calling this method for the first time, I18n gem is loaded. In v0.3.1, it takes 45-50 seconds on my machine to get out of `step` rabbit hole. After this patch, it is cut down to 7 seconds (5 to reach the threshold and 2 to get out)
