### PR TITLE
Cover more edge cases when resize window

### DIFF
--- a/lib/ruby_jard/commands/output_command.rb
+++ b/lib/ruby_jard/commands/output_command.rb
@@ -11,7 +11,7 @@ module RubyJard
 
       def initialize(*args)
         super(*args)
-        @session = (context[:session] || RubyJard::Session.instance)
+        @stdout_storage = RubyJard::Console.stdout_storage
       end
 
       def process
@@ -21,7 +21,7 @@ module RubyJard
           pager_start_at_the_end: true,
           prompt: 'Program output'
         ) do |pager|
-          @session.output_buffer.each do |string|
+          @stdout_storage.each do |string|
             string.each do |s|
               pager.write(s)
             end

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -195,6 +195,7 @@ module RubyJard
       @resizing = true
       @resizing_output_mark = @console.stdout_storage.length
       sleep PTY_OUTPUT_TIMEOUT while @state.processing?
+      @resizing_readline_buffer = Readline.line_buffer
       if @main_thread&.alive?
         @main_thread.raise FlowInterrupt.new('Resize event', RubyJard::ControlFlow.new(:list))
       end
@@ -210,6 +211,10 @@ module RubyJard
           @pry_output_pty_write.write(s)
         end
       end
+      unless @resizing_readline_buffer.nil?
+        @pry_input_pipe_write.write(@resizing_readline_buffer)
+      end
+      @resizing_readline_buffer = nil
       @resizing_output_mark = nil
       @resizing = false
     end

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -222,8 +222,12 @@ module RubyJard
     end
 
     def pry_repl(current_binding)
-      flow = RubyJard::ControlFlow.listen do
-        pry_instance.repl(current_binding)
+      flow = nil
+      loop do
+        flow = RubyJard::ControlFlow.listen do
+          pry_instance.repl(current_binding)
+        end
+        break if flow != nil
       end
       @state.check(:ready?) do
         @main_thread.raise FlowInterrupt.new('Interrupt from repl thread', flow)

--- a/lib/ruby_jard/repl_proxy.rb
+++ b/lib/ruby_jard/repl_proxy.rb
@@ -145,13 +145,13 @@ module RubyJard
 
     # rubocop:disable Metrics/MethodLength
     def repl(current_binding)
+      reopen_streams
       finish_resizing
 
       @state.ready!
       @openning_pager = false
       @console.disable_echo!
       @console.raw!
-
       # Internally, Pry sneakily updates Readline to global output config
       # when STDOUT is piping regardless of what I pass into Pry instance.
       Pry.config.output = @pry_output_pty_write
@@ -214,6 +214,16 @@ module RubyJard
       @resizing = false
     end
 
+    def reopen_streams
+      if @pry_input_pipe_read.closed? || @pry_input_pipe_write.closed?
+        @pry_input_pipe_read, @pry_input_pipe_write = IO.pipe
+      end
+
+      if @pry_output_pty_read.closed? || @pry_output_pty_write.closed?
+        @pry_output_pty_read, @pry_output_pty_write = PTY.open
+      end
+    end
+
     def read_key
       @console.getch(KEY_READ_TIMEOUT)
     end
@@ -248,6 +258,8 @@ module RubyJard
       flow = RubyJard::ControlFlow.listen do
         pry_instance.repl(current_binding)
       end
+      return if flow.nil?
+
       @state.check(:ready?) do
         @main_thread.raise FlowInterrupt.new('Interrupt from repl thread', flow)
       end
@@ -255,6 +267,7 @@ module RubyJard
 
     def listen_key_press
       loop do
+        break if @pry_input_pipe_write.closed?
         break if @state.exiting? || @state.exited?
 
         if @state.processing? && @openning_pager
@@ -270,6 +283,8 @@ module RubyJard
           end
         end
       end
+    rescue IOError
+      # Nothing we can do about it, let the program continues
     end
 
     def handle_key_binding(key_binding)

--- a/spec/integration/auto_layout/auto_layout_spec.rb
+++ b/spec/integration/auto_layout/auto_layout_spec.rb
@@ -88,4 +88,67 @@ RSpec.describe 'Auto layout', integration: true do
       test.stop
     end
   end
+
+  context 'when a window is resized during evaluation' do
+    it 'defers the resizing event until finish' do
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'resize_evaluation.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('3.times { sleep 1 }', :Enter)
+      sleep 1
+      test.resize(50, 60)
+      sleep 3
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when a window is resized multiple time' do
+    it 'ignores the sequential resizing event' do
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'resize_multiple.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('3.times { sleep 1 }', :Enter)
+      sleep 1
+      test.resize(50, 60)
+      test.resize(50, 62)
+      test.resize(50, 63)
+      sleep 3
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
+
+  context 'when there is input during evaluation after resize event' do
+    it 'repeat output after resize events' do
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'resize_output.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+      )
+      test.start
+      test.assert_screen
+      # rubocop:disable Lint/InterpolationCheck
+      test.send_keys('puts "Input before"; 3.times { |i| sleep 1; puts "Input #{i}" }', :Enter)
+      # rubocop:enable Lint/InterpolationCheck
+      sleep 0.5
+      test.resize(50, 60)
+      test.resize(50, 62)
+      test.resize(50, 63)
+      sleep 4
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
 end

--- a/spec/integration/auto_layout/auto_layout_spec.rb
+++ b/spec/integration/auto_layout/auto_layout_spec.rb
@@ -151,4 +151,25 @@ RSpec.describe 'Auto layout', integration: true do
       test.stop
     end
   end
+
+  context 'when there is pending input in REPL during resize event' do
+    it 'reserves input text to after resizing' do
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'resize_pending_input.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('a = 1 +')
+      test.resize(50, 60)
+      test.resize(50, 63)
+      sleep 0.5
+      test.assert_screen
+      test.send_keys(' 2', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
+  end
 end

--- a/spec/integration/auto_layout/resize_evaluation.expected
+++ b/spec/integration/auto_layout/resize_evaluation.expected
@@ -1,0 +1,83 @@
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ──────────────────────────────┐
+│   7 var_c = ['Hello', 1, 2, 3]                                               │
+│   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
+│   9 variable_e = /Wait, what/i                                               │
+│  10 variable_f = 1.1                                                         │
+│  11 variable_g = 99..100                                                     │
+│  12 variable_k = StandardError.new('A random error')                         │
+│  13                                                                          │
+│  14 jard                                                                     │
+│⮕ 15 variable_h = 15                                                          │
+│  16                                                                          │
+│  17 jard                                                                     │
+│  18 1.times {}                                                               │
+│  19                                                                          │
+│  20 jard                                                                     │
+│  21 var_a + variable_f + variable_h || 5                                     │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+### END SCREEN ###
+### START SEND_KEYS ###
+["3.times { sleep 1 }", :Enter]
+### END SEND_KEYS ###
+### START RESIZE ###
+Resize to 50, 60
+### END RESIZE ###
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   2                                            │
+│   3 require 'ruby_jard'                        │
+│   4                                            │
+│   5 var_a = 123                                │
+│   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
+│   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
+│   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
+│  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
+│     ror')                                      │
+│  13                                            │
+│  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
+│  16                                            │
+│  17 jard                                       │
+│  18 1.times {}                                 │
+│  19                                            │
+│  20 jard                                       │
+│  21 var_a + variable_f + variable_h || 5       │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+├ Variables ─────────────────────────────────────┤
+│  self = main                                   │
+│  var_a = 123                                   │
+│  var_b = "hello world"                         │
+│▾ var_c (len:4) = [                             │
+│    ▸ "Hello"                                   │
+│    ▸ 1                                         │
+│    ▸ 2                                         │
+│    ▸ 3                                         │
+│  ]                                             │
+│  variable_d (size:3) = {:test → 1, :this → "Bye│
+│  ", :array → nil}                              │
+│  variable_e = /Wait, what/i                    │
+│  variable_f = 1.1                              │
+│  variable_g = 99..100                          │
+│  variable_h = nil                              │
+│  variable_k = #<StandardError: A random error> │
+│                                                │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Ou »│
+└────────────────────────────────────────────────┘
+jard >>     
+### END SCREEN ###

--- a/spec/integration/auto_layout/resize_multiple.expected
+++ b/spec/integration/auto_layout/resize_multiple.expected
@@ -1,0 +1,91 @@
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ──────────────────────────────┐
+│   7 var_c = ['Hello', 1, 2, 3]                                               │
+│   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
+│   9 variable_e = /Wait, what/i                                               │
+│  10 variable_f = 1.1                                                         │
+│  11 variable_g = 99..100                                                     │
+│  12 variable_k = StandardError.new('A random error')                         │
+│  13                                                                          │
+│  14 jard                                                                     │
+│⮕ 15 variable_h = 15                                                          │
+│  16                                                                          │
+│  17 jard                                                                     │
+│  18 1.times {}                                                               │
+│  19                                                                          │
+│  20 jard                                                                     │
+│  21 var_a + variable_f + variable_h || 5                                     │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+### END SCREEN ###
+### START SEND_KEYS ###
+["3.times { sleep 1 }", :Enter]
+### END SEND_KEYS ###
+### START RESIZE ###
+Resize to 50, 60
+### END RESIZE ###
+### START RESIZE ###
+Resize to 50, 62
+### END RESIZE ###
+### START RESIZE ###
+Resize to 50, 63
+### END RESIZE ###
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   1 # frozen_string_literal: true              │
+│   2                                            │
+│   3 require 'ruby_jard'                        │
+│   4                                            │
+│   5 var_a = 123                                │
+│   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
+│   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
+│   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
+│  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
+│     ror')                                      │
+│  13                                            │
+│  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
+│  16                                            │
+│  17 jard                                       │
+│  18 1.times {}                                 │
+│  19                                            │
+│  20 jard                                       │
+│  21 var_a + variable_f + variable_h || 5       │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+├ Variables ─────────────────────────────────────┤
+│  self = main                                   │
+│  var_a = 123                                   │
+│  var_b = "hello world"                         │
+│▾ var_c (len:4) = [                             │
+│    ▸ "Hello"                                   │
+│    ▸ 1                                         │
+│    ▸ 2                                         │
+│    ▸ 3                                         │
+│  ]                                             │
+│  variable_d (size:3) = {:test → 1, :this → "Bye│
+│  ", :array → nil}                              │
+│  variable_e = /Wait, what/i                    │
+│  variable_f = 1.1                              │
+│  variable_g = 99..100                          │
+│  variable_h = nil                              │
+│  variable_k = #<StandardError: A random error> │
+│                                                │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Ou »│
+└────────────────────────────────────────────────┘
+jard >>     
+### END SCREEN ###

--- a/spec/integration/auto_layout/resize_output.expected
+++ b/spec/integration/auto_layout/resize_output.expected
@@ -1,0 +1,94 @@
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ──────────────────────────────┐
+│   7 var_c = ['Hello', 1, 2, 3]                                               │
+│   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
+│   9 variable_e = /Wait, what/i                                               │
+│  10 variable_f = 1.1                                                         │
+│  11 variable_g = 99..100                                                     │
+│  12 variable_k = StandardError.new('A random error')                         │
+│  13                                                                          │
+│  14 jard                                                                     │
+│⮕ 15 variable_h = 15                                                          │
+│  16                                                                          │
+│  17 jard                                                                     │
+│  18 1.times {}                                                               │
+│  19                                                                          │
+│  20 jard                                                                     │
+│  21 var_a + variable_f + variable_h || 5                                     │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+### END SCREEN ###
+### START SEND_KEYS ###
+["puts \"Input before\"; 3.times { |i| sleep 1; puts \"Input \#{i}\" }", :Enter]
+### END SEND_KEYS ###
+### START RESIZE ###
+Resize to 50, 60
+### END RESIZE ###
+### START RESIZE ###
+Resize to 50, 62
+### END RESIZE ###
+### START RESIZE ###
+Resize to 50, 63
+### END RESIZE ###
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   1 # frozen_string_literal: true              │
+│   2                                            │
+│   3 require 'ruby_jard'                        │
+│   4                                            │
+│   5 var_a = 123                                │
+│   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
+│   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
+│   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
+│  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
+│     ror')                                      │
+│  13                                            │
+│  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
+│  16                                            │
+│  17 jard                                       │
+│  18 1.times {}                                 │
+│  19                                            │
+│  20 jard                                       │
+│  21 var_a + variable_f + variable_h || 5       │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+├ Variables ─────────────────────────────────────┤
+│  self = main                                   │
+│  var_a = 123                                   │
+│  var_b = "hello world"                         │
+│▾ var_c (len:4) = [                             │
+│    ▸ "Hello"                                   │
+│    ▸ 1                                         │
+│    ▸ 2                                         │
+│    ▸ 3                                         │
+│  ]                                             │
+│  variable_d (size:3) = {:test → 1, :this → "Bye│
+│  ", :array → nil}                              │
+│  variable_e = /Wait, what/i                    │
+│  variable_f = 1.1                              │
+│  variable_g = 99..100                          │
+│  variable_h = nil                              │
+│  variable_k = #<StandardError: A random error> │
+│                                                │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Ou »│
+└────────────────────────────────────────────────┘
+Input 0     
+Input 1     
+Input 2     
+jard >>     
+### END SCREEN ###

--- a/spec/integration/auto_layout/resize_pending_input.expected
+++ b/spec/integration/auto_layout/resize_pending_input.expected
@@ -1,0 +1,148 @@
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ──────────────────────────────┐
+│   7 var_c = ['Hello', 1, 2, 3]                                               │
+│   8 variable_d = { test: 1, this: 'Bye', array: nil }                        │
+│   9 variable_e = /Wait, what/i                                               │
+│  10 variable_f = 1.1                                                         │
+│  11 variable_g = 99..100                                                     │
+│  12 variable_k = StandardError.new('A random error')                         │
+│  13                                                                          │
+│  14 jard                                                                     │
+│⮕ 15 variable_h = 15                                                          │
+│  16                                                                          │
+│  17 jard                                                                     │
+│  18 1.times {}                                                               │
+│  19                                                                          │
+│  20 jard                                                                     │
+│  21 var_a + variable_f + variable_h || 5                                     │
+│                                                                              │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
+└──────────────────────────────────────────────────────────────────────────────┘
+jard >>             
+### END SCREEN ###
+### START SEND_KEYS ###
+["a = 1 +"]
+### END SEND_KEYS ###
+### START RESIZE ###
+Resize to 50, 60
+### END RESIZE ###
+### START RESIZE ###
+Resize to 50, 63
+### END RESIZE ###
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   1 # frozen_string_literal: true              │
+│   2                                            │
+│   3 require 'ruby_jard'                        │
+│   4                                            │
+│   5 var_a = 123                                │
+│   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
+│   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
+│   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
+│  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
+│     ror')                                      │
+│  13                                            │
+│  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
+│  16                                            │
+│  17 jard                                       │
+│  18 1.times {}                                 │
+│  19                                            │
+│  20 jard                                       │
+│  21 var_a + variable_f + variable_h || 5       │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+├ Variables ─────────────────────────────────────┤
+│  self = main                                   │
+│  var_a = 123                                   │
+│  var_b = "hello world"                         │
+│▾ var_c (len:4) = [                             │
+│    ▸ "Hello"                                   │
+│    ▸ 1                                         │
+│    ▸ 2                                         │
+│    ▸ 3                                         │
+│  ]                                             │
+│  variable_d (size:3) = {:test → 1, :this → "Bye│
+│  ", :array → nil}                              │
+│  variable_e = /Wait, what/i                    │
+│  variable_f = 1.1                              │
+│  variable_g = 99..100                          │
+│  variable_h = nil                              │
+│  variable_k = #<StandardError: A random error> │
+│                                                │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Ou »│
+└────────────────────────────────────────────────┘
+jard >> a = 1 +          
+### END SCREEN ###
+### START SEND_KEYS ###
+[" 2", :Enter]
+### END SEND_KEYS ###
+### START SCREEN ###
+┌ Source  ../../examples/top_level_example.rb:15 ┐
+│   1 # frozen_string_literal: true              │
+│   2                                            │
+│   3 require 'ruby_jard'                        │
+│   4                                            │
+│   5 var_a = 123                                │
+│   6 var_b = 'hello world'                      │
+│   7 var_c = ['Hello', 1, 2, 3]                 │
+│   8 variable_d = { test: 1, this: 'Bye', array:│
+│      nil }                                     │
+│   9 variable_e = /Wait, what/i                 │
+│  10 variable_f = 1.1                           │
+│  11 variable_g = 99..100                       │
+│  12 variable_k = StandardError.new('A random er│
+│     ror')                                      │
+│  13                                            │
+│  14 jard                                       │
+│⮕ 15 variable_h = 15                            │
+│  16                                            │
+│  17 jard                                       │
+│  18 1.times {}                                 │
+│  19                                            │
+│  20 jard                                       │
+│  21 var_a + variable_f + variable_h || 5       │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+│                                                │
+├ Variables ─────────────────────────────────────┤
+│  self = main                                   │
+│  var_a = 123                                   │
+│  var_b = "hello world"                         │
+│▾ var_c (len:4) = [                             │
+│    ▸ "Hello"                                   │
+│    ▸ 1                                         │
+│    ▸ 2                                         │
+│    ▸ 3                                         │
+│  ]                                             │
+│  variable_d (size:3) = {:test → 1, :this → "Bye│
+│  ", :array → nil}                              │
+│  variable_e = /Wait, what/i                    │
+│  variable_f = 1.1                              │
+│  variable_g = 99..100                          │
+│  variable_h = nil                              │
+│  variable_k = #<StandardError: A random error> │
+│                                                │
+│                                                │
+│                                                │
+├────────────────────────────────────────────────┤
+│Filter (F2): Application   Step (F7)   Step Ou »│
+└────────────────────────────────────────────────┘
+jard >> a = 1 + 2        
+=> 3        
+jard >>     
+### END SCREEN ###


### PR DESCRIPTION
In recent implementation, whenever the window is resized, a control flow event is raised, and captured by outsider, and redraw the screen. There are known issues:
- If Jard is processing a line of code in REPL, resize event interrupts the processing, and pops out. It's unexpected, and annoying for anyone who uses tmux.
- If the main thread is sleeping, or busy, the resize events may cause `resize event` error, and crash the process (https://github.com/nguyenquangminh0711/ruby_jard/issues/70)
- Pending input is lost during resizing

So, it's better to defer the resizing event to whenever REPL session is idle. However, at that time, if there is any output printed out during the evaluation, the users may not see it as the screen is refresh. therefore, I decided to replay the output into the screen after resizing is done.
![Screenshot from 2020-10-09 16-19-57](https://user-images.githubusercontent.com/11613517/95566109-5502bd80-0a4b-11eb-8fc0-1f2354ab6c88.png)
