### PR TITLE
Support ruby 2.4

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7.2, head]
+        ruby: [2.4, 2.5, 2.6, 2.7.2, head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,6 @@ RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   Exclude:
       - '**/*_example.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'tty-markdown', '~>0.7.0'
 group :test do
   gem 'activerecord'
   gem 'parallel_tests'
-  gem 'rb-readline', require: false
+  gem 'reline', require: false
   gem 'rspec-retry'
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'tty-markdown', '~>0.7.0'
 group :test do
   gem 'activerecord'
   gem 'parallel_tests'
-  gem 'reline', require: false
+  gem 'rb-readline', require: false
   gem 'rspec-retry'
   gem 'sqlite3'
 end

--- a/lib/ruby_jard/commands/filter_command.rb
+++ b/lib/ruby_jard/commands/filter_command.rb
@@ -72,7 +72,7 @@ module RubyJard
                 "Please type `#{highlight('jard filter --help')}` for more information"
         end
         filters = args.map(&:strip)
-        included = @config.filter_included.dup.append(*filters).uniq
+        included = @config.filter_included.dup.push(*filters).uniq
         excluded = @config.filter_excluded.dup
         filters.each do |filter|
           excluded.delete(filter) if excluded.include?(filter)
@@ -92,7 +92,7 @@ module RubyJard
         filters = args.map(&:strip)
 
         included = @config.filter_included.dup
-        excluded = @config.filter_excluded.dup.append(*filters).uniq
+        excluded = @config.filter_excluded.dup.push(*filters).uniq
 
         filters.each do |filter|
           included.delete(filter) if included.include?(filter)

--- a/lib/ruby_jard/path_classifier.rb
+++ b/lib/ruby_jard/path_classifier.rb
@@ -82,8 +82,20 @@ module RubyJard
     def try_classify_stdlib(path)
       lib_dir = RbConfig::CONFIG['rubylibdir'].to_s.strip
 
-      return false if lib_dir.empty?
-      return false unless path.start_with?(lib_dir)
+      # site_ruby is a place where user can override stdlib, we can classify it
+      # as stdlib
+      site_ruby_lib_dir = RbConfig::CONFIG['sitelibdir'].to_s.strip
+
+      return false if lib_dir.empty? && site_ruby_dir.empty?
+
+      lib_dir =
+        if path.start_with?(lib_dir)
+          lib_dir
+        elsif path.start_with?(site_ruby_lib_dir)
+          site_ruby_lib_dir
+        end
+
+      return false unless lib_dir
 
       splitted_path =
         path[lib_dir.length..-1]

--- a/lib/ruby_jard/screens/variables_screen.rb
+++ b/lib/ruby_jard/screens/variables_screen.rb
@@ -143,9 +143,11 @@ module RubyJard
           end
         variables -= pry_sticky_locals
         variables.map do |variable|
-          [KIND_LOC, variable, @frame_binding.local_variable_get(variable)]
-        rescue NameError
-          nil
+          begin
+            [KIND_LOC, variable, @frame_binding.local_variable_get(variable)]
+          rescue NameError
+            nil
+          end
         end.compact
       end
 
@@ -158,9 +160,11 @@ module RubyJard
           .select { |v| relevant?(KIND_INS, v) }
 
         instance_variables.map do |variable|
-          [KIND_INS, variable, @reflection.call_instance_variable_get(@frame_self, variable)]
-        rescue NameError
-          nil
+          begin
+            [KIND_INS, variable, @reflection.call_instance_variable_get(@frame_self, variable)]
+          rescue NameError
+            nil
+          end
         end.compact
       end
 
@@ -200,9 +204,11 @@ module RubyJard
           .global_variables
           .select { |v| relevant?(KIND_GLOB, v) }
         variables.map do |variable|
-          [KIND_GLOB, variable, ::Kernel.instance_eval(variable.to_s)]
-        rescue NameError
-          nil
+          begin
+            [KIND_GLOB, variable, ::Kernel.instance_eval(variable.to_s)]
+          rescue NameError
+            nil
+          end
         end.compact
       end
 

--- a/ruby_jard.gemspec
+++ b/ruby_jard.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
                         editors.'
   spec.homepage      = 'https://github.com/nguyenquangminh0711/ruby_jard'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/spec/examples/placement_5_example.rb
+++ b/spec/examples/placement_5_example.rb
@@ -10,4 +10,4 @@ VIEW
 erb = ERB.new(view)
 erb.filename = __FILE__
 erb.lineno = lineno
-erb.result_with_hash({})
+erb.result

--- a/spec/examples/readline_patched.rb
+++ b/spec/examples/readline_patched.rb
@@ -8,8 +8,12 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5')
 else
   # Faking using another implementation
   module Readline
-    def self.input=(value)
-      super
+    class << self
+      alias_method :original_input=, :input=
+
+      def input=(input)
+        self.original_input = input
+      end
     end
   end
 end

--- a/spec/examples/readline_patched.rb
+++ b/spec/examples/readline_patched.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
-require 'readline'
+require 'reline'
 require 'ruby_jard'
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5')
+  Readline = Reline
+else
+  # Faking using another implementation
+  module Readline
+    def self.input=(value)
+      super
+    end
+  end
+end
 
 class Calculator
   def calculate(a, b, c)

--- a/spec/examples/readline_patched.rb
+++ b/spec/examples/readline_patched.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'reline'
+require 'readline'
 require 'ruby_jard'
-
-Readline = Reline
 
 class Calculator
   def calculate(a, b, c)

--- a/spec/integration/auto_layout/auto_layout_spec.rb
+++ b/spec/integration/auto_layout/auto_layout_spec.rb
@@ -5,171 +5,189 @@ RSpec.describe 'Auto layout', integration: true do
 
   context 'when the window is enormous' do
     it 'picks wide layout' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'enormous.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 121, height: 30
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'enormous.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 121, height: 30
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when the window can only fit 1 screen' do
     it 'picks tiny layout' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'tiny.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 30, height: 30
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'tiny.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 30, height: 30
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when the screen is short, but wide' do
     it 'picks narrow horizontal layout' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'horizontal.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 130, height: 15
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'horizontal.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 130, height: 15
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when the screen is tall, but narrow' do
     it 'picks narrow vertical layout' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'vertical.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 50, height: 50
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'vertical.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 50, height: 50
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when a window is resized' do
     it 'resizes and choose a right layout' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'resize.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.resize(50, 60)
-      test.assert_screen
-      test.resize(50, 40)
-      test.assert_screen
-      test.resize(121, 30)
-      test.assert_screen
-      test.resize(121, 20)
-      test.assert_screen
-      test.resize(100, 50)
-      test.assert_screen
-      test.resize(140, 70)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'resize.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.resize(50, 60)
+        test.assert_screen
+        test.resize(50, 40)
+        test.assert_screen
+        test.resize(121, 30)
+        test.assert_screen
+        test.resize(121, 20)
+        test.assert_screen
+        test.resize(100, 50)
+        test.assert_screen
+        test.resize(140, 70)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when a window is resized during evaluation' do
     it 'defers the resizing event until finish' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'resize_evaluation.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('3.times { sleep 1 }', :Enter)
-      sleep 1
-      test.resize(50, 60)
-      sleep 3
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'resize_evaluation.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('3.times { sleep 1 }', :Enter)
+        sleep 1
+        test.resize(50, 60)
+        sleep 3
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when a window is resized multiple time' do
     it 'ignores the sequential resizing event' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'resize_multiple.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('3.times { sleep 1 }', :Enter)
-      sleep 1
-      test.resize(50, 60)
-      test.resize(50, 62)
-      test.resize(50, 63)
-      sleep 3
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'resize_multiple.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('3.times { sleep 1 }', :Enter)
+        sleep 1
+        test.resize(50, 60)
+        test.resize(50, 62)
+        test.resize(50, 63)
+        sleep 3
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when there is input during evaluation after resize event' do
     it 'repeat output after resize events' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'resize_output.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      # rubocop:disable Lint/InterpolationCheck
-      test.send_keys('puts "Input before"; 3.times { |i| sleep 1; puts "Input #{i}" }', :Enter)
-      # rubocop:enable Lint/InterpolationCheck
-      sleep 0.5
-      test.resize(50, 60)
-      test.resize(50, 62)
-      test.resize(50, 63)
-      sleep 4
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'resize_output.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        # rubocop:disable Lint/InterpolationCheck
+        test.send_keys('puts "Input before"; 3.times { |i| sleep 1; puts "Input #{i}" }', :Enter)
+        # rubocop:enable Lint/InterpolationCheck
+        sleep 0.5
+        test.resize(50, 60)
+        test.resize(50, 62)
+        test.resize(50, 63)
+        sleep 4
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when there is pending input in REPL during resize event' do
     it 'reserves input text to after resizing' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'resize_pending_input.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('a = 1 +')
-      test.resize(50, 60)
-      test.resize(50, 63)
-      sleep 0.5
-      test.assert_screen
-      test.send_keys(' 2', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'resize_pending_input.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('a = 1 +')
+        test.resize(50, 60)
+        test.resize(50, 63)
+        sleep 0.5
+        test.assert_screen
+        test.send_keys(' 2', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/commands/pager_spec.rb
+++ b/spec/integration/commands/pager_spec.rb
@@ -5,42 +5,44 @@ RSpec.describe 'Pager tests', integration: true do
 
   context 'when output directly into screen' do
     it 'display pager perfectly' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'pager.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/pager_example.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'pager.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/pager_example.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('hash_a', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
+        test.send_keys('hash_a', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
 
-      test.send_keys('hash_b', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
+        test.send_keys('hash_b', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
 
-      test.send_keys('hash_c', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
+        test.send_keys('hash_c', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
 
-      test.send_keys('hash_d', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
+        test.send_keys('hash_d', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
 
-      test.send_keys('hash_e', :Enter)
-      test.assert_screen
-      test.send_keys('G')
-      test.assert_screen
-      test.send_keys('gg')
-      test.assert_screen
-      test.send_keys('/variable_17', :Enter)
-      test.assert_screen
-      test.send_keys('q')
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('hash_e', :Enter)
+        test.assert_screen
+        test.send_keys('G')
+        test.assert_screen
+        test.send_keys('gg')
+        test.assert_screen
+        test.send_keys('/variable_17', :Enter)
+        test.assert_screen
+        test.send_keys('q')
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/commands/show_output_spec.rb
+++ b/spec/integration/commands/show_output_spec.rb
@@ -5,64 +5,70 @@ RSpec.describe 'Output Integration tests', integration: true do
 
   context 'when there is no output yet' do
     it 'displays empty pager' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'show_output.no_output.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'show_output.no_output.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when there the output fits into the screen' do
     it 'displays full pager stopping at the end of file' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'show_output.fit.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'show_output.fit.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when there the output overflow the screen' do
     it 'displays interactive pager fit into the screen' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'show_output.overflow.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'show_output.overflow.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/program_output_example.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('next', :Enter)
-      test.send_keys('next', :Enter)
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
+        test.send_keys('next', :Enter)
+        test.send_keys('next', :Enter)
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
 
-      test.send_keys('k')
-      test.assert_screen
+        test.send_keys('k')
+        test.assert_screen
 
-      test.send_keys('g')
-      sleep 1
-      test.assert_screen
+        test.send_keys('g')
+        sleep 1
+        test.assert_screen
 
-      test.send_keys('q')
-      sleep 1
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('q')
+        sleep 1
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/commands/switch_color_scheme_spec.rb
+++ b/spec/integration/commands/switch_color_scheme_spec.rb
@@ -5,49 +5,55 @@ RSpec.describe 'color-scheme command', integration: true do
 
   context 'when list color schemes' do
     it 'displays list of schemes' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'scheme.list.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard color-scheme -l', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'scheme.list.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard color-scheme -l', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when switching to new scheme' do
     it 'displays no error' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'scheme.switch.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard color-scheme 256', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'scheme.switch.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard color-scheme 256', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when switching to not-found scheme' do
     it 'displays error' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'scheme.switch_not_found.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard color-scheme NotExistedScheme', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'scheme.switch_not_found.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard color-scheme NotExistedScheme', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/compatibilities/compatibilities_spec.rb
+++ b/spec/integration/compatibilities/compatibilities_spec.rb
@@ -5,119 +5,131 @@ RSpec.describe 'Byebug compatibility', integration: true do
 
   context 'when attach into program with byebug command' do
     it 'byebug command still works along with Jard' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_byebug.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/byebug_example.rb",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_byebug.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/byebug_example.rb",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when attach into program with debugger command' do
     it 'debugger command still works along with Jard' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_debugger.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/debugger_example.rb",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_debugger.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/debugger_example.rb",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when attach into program with binding.pry command' do
     it 'binding.pry command still works along with Jard' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_binding_pry.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/binding_pry_example.rb",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_binding_pry.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/binding_pry_example.rb",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('exit', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('exit', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when attach into program with mixed binding.pry and jard command' do
     it 'binding.pry command still works along with Jard' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_binding_pry_mixed.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/binding_pry_mixed_example.rb",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_binding_pry_mixed.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/binding_pry_mixed_example.rb",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
 
-      test.send_keys('exit', :Enter)
-      test.assert_screen
+        test.send_keys('exit', :Enter)
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when PTY not found' do
     it 'ignores interceptor and use direct input instead' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_pty_not_found.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/pty_not_found.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_pty_not_found.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/pty_not_found.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when Readline is patched' do
     it 'ignores interceptor and use direct input instead' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'compatibility_readline_patched.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/readline_patched.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'compatibility_readline_patched.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/readline_patched.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/compatibilities/compatibility_readline_patched.expected
+++ b/spec/integration/compatibilities/compatibility_readline_patched.expected
@@ -1,76 +1,76 @@
 ### START SCREEN ###
-┌ Source  ../../examples/readline_patched.rb:11 ───────────────────────────────┐
-│   3 require 'reline'                                                         │
-│   4 require 'ruby_jard'                                                      │
-│   5                                                                          │
-│   6 Readline = Reline                                                        │
-│   7                                                                          │
-│   8 class Calculator                                                         │
-│   9   def calculate(a, b, c)                                                 │
-│  10     jard                                                                 │
-│⮕ 11     d = a + b                                                            │
-│  12     jard                                                                 │
-│  13     e = d + 10                                                           │
-│  14     jard                                                                 │
-│  15     e + c                                                                │
-│  16   end                                                                    │
-│  17 end                                                                      │
-│  18                                                                          │
-│  19 Calculator.new.calculate(1, 2, 3)                                        │
+┌ Source  ../../examples/readline_patched.rb:24 ───────────────────────────────┐
+│  16       end                                                                │
+│  17     end                                                                  │
+│  18   end                                                                    │
+│  19 end                                                                      │
+│  20                                                                          │
+│  21 class Calculator                                                         │
+│  22   def calculate(a, b, c)                                                 │
+│  23     jard                                                                 │
+│⮕ 24     d = a + b                                                            │
+│  25     jard                                                                 │
+│  26     e = d + 10                                                           │
+│  27     jard                                                                 │
+│  28     e + c                                                                │
+│  29   end                                                                    │
+│  30 end                                                                      │
+│  31                                                                          │
+│  32 Calculator.new.calculate(1, 2, 3)                                        │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
 └──────────────────────────────────────────────────────────────────────────────┘
 *Warning*: One of Jard's depedencies (PTY or Readline) is not available or patch
-ed by another gem. Key bindings are disabled. There may be other side effects.  
-jard >>             
+ed by another gem. Key bindings are disabled. There may be other side effects.
+jard >>
 ### END SCREEN ###
 ### START SEND_KEYS ###
 ["continue", :Enter]
 ### END SEND_KEYS ###
 ### START SCREEN ###
-┌ Source  ../../examples/readline_patched.rb:13 ───────────────────────────────┐
-│   5                                                                          │
-│   6 Readline = Reline                                                        │
-│   7                                                                          │
-│   8 class Calculator                                                         │
-│   9   def calculate(a, b, c)                                                 │
-│  10     jard                                                                 │
-│  11     d = a + b                                                            │
-│  12     jard                                                                 │
-│⮕ 13     e = d + 10                                                           │
-│  14     jard                                                                 │
-│  15     e + c                                                                │
-│  16   end                                                                    │
-│  17 end                                                                      │
-│  18                                                                          │
-│  19 Calculator.new.calculate(1, 2, 3)                                        │
+┌ Source  ../../examples/readline_patched.rb:26 ───────────────────────────────┐
+│  18   end                                                                    │
+│  19 end                                                                      │
+│  20                                                                          │
+│  21 class Calculator                                                         │
+│  22   def calculate(a, b, c)                                                 │
+│  23     jard                                                                 │
+│  24     d = a + b                                                            │
+│  25     jard                                                                 │
+│⮕ 26     e = d + 10                                                           │
+│  27     jard                                                                 │
+│  28     e + c                                                                │
+│  29   end                                                                    │
+│  30 end                                                                      │
+│  31                                                                          │
+│  32 Calculator.new.calculate(1, 2, 3)                                        │
 │                                                                              │
 │                                                                              │
 ├──────────────────────────────────────────────────────────────────────────────┤
 │Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
 └──────────────────────────────────────────────────────────────────────────────┘
 *Warning*: One of Jard's depedencies (PTY or Readline) is not available or patch
-ed by another gem. Key bindings are disabled. There may be other side effects.  
-jard >>             
+ed by another gem. Key bindings are disabled. There may be other side effects.
+jard >>
 ### END SCREEN ###
 ### START SEND_KEYS ###
 ["continue", :Enter]
 ### END SEND_KEYS ###
 ### START SCREEN ###
-┌ Source  ../../examples/readline_patched.rb:15 ───────────────────────────────┐
-│   7                                                                          │
-│   8 class Calculator                                                         │
-│   9   def calculate(a, b, c)                                                 │
-│  10     jard                                                                 │
-│  11     d = a + b                                                            │
-│  12     jard                                                                 │
-│  13     e = d + 10                                                           │
-│  14     jard                                                                 │
-│⮕ 15     e + c                                                                │
-│  16   end                                                                    │
-│  17 end                                                                      │
-│  18                                                                          │
-│  19 Calculator.new.calculate(1, 2, 3)                                        │
+┌ Source  ../../examples/readline_patched.rb:28 ───────────────────────────────┐
+│  20                                                                          │
+│  21 class Calculator                                                         │
+│  22   def calculate(a, b, c)                                                 │
+│  23     jard                                                                 │
+│  24     d = a + b                                                            │
+│  25     jard                                                                 │
+│  26     e = d + 10                                                           │
+│  27     jard                                                                 │
+│⮕ 28     e + c                                                                │
+│  29   end                                                                    │
+│  30 end                                                                      │
+│  31                                                                          │
+│  32 Calculator.new.calculate(1, 2, 3)                                        │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -79,6 +79,6 @@ jard >>
 │Filter (F2): Application   Step (F7)   Step Out (Shift+F7)   Next (F8)   Con »│
 └──────────────────────────────────────────────────────────────────────────────┘
 *Warning*: One of Jard's depedencies (PTY or Readline) is not available or patch
-ed by another gem. Key bindings are disabled. There may be other side effects.  
-jard >>             
+ed by another gem. Key bindings are disabled. There may be other side effects.
+jard >>
 ### END SCREEN ###

--- a/spec/integration/custom_key_bindings/custom_key_bindings_spec.rb
+++ b/spec/integration/custom_key_bindings/custom_key_bindings_spec.rb
@@ -4,35 +4,37 @@ RSpec.describe 'Custom key bindings', integration: true do
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/custom_key_bindings') }
 
   it 'supports custom key binding in the configuration file' do
-    test = JardIntegrationTest.new(
-      self, work_dir,
-      'custom_key_bindings.expected',
-      "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_instance_example.rb"
-    )
-    test.start
-    test.assert_screen
-    test.send_keys(:"C-M-n") # Next
-    test.assert_screen
-    test.send_keys(:"C-M-n") # Next
-    test.send_keys(:"M-d") # Step
-    test.assert_screen
-    test.send_keys(:"C-F1") # Up
-    test.assert_screen
-    test.send_keys(:"C-S-F1") # Down
-    test.assert_screen
-    test.send_keys(:"M-o") # Step out
-    test.assert_screen
-    test.send_keys(:"M-F1") # Continue
-    test.assert_screen
-    test.send_keys(:"M-S-F1") # Continue too
-    test.assert_screen
-    test.send_keys('hello') # Continue too
-    test.assert_screen
-    test.send_keys(:"M-l") # List
-    test.assert_screen
-    test.send_keys(:"C-n") # Switch
-    test.assert_screen
-  ensure
-    test.stop
+    begin
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'custom_key_bindings.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_instance_example.rb"
+      )
+      test.start
+      test.assert_screen
+      test.send_keys(:"C-M-n") # Next
+      test.assert_screen
+      test.send_keys(:"C-M-n") # Next
+      test.send_keys(:"M-d") # Step
+      test.assert_screen
+      test.send_keys(:"C-F1") # Up
+      test.assert_screen
+      test.send_keys(:"C-S-F1") # Down
+      test.assert_screen
+      test.send_keys(:"M-o") # Step out
+      test.assert_screen
+      test.send_keys(:"M-F1") # Continue
+      test.assert_screen
+      test.send_keys(:"M-S-F1") # Continue too
+      test.assert_screen
+      test.send_keys('hello') # Continue too
+      test.assert_screen
+      test.send_keys(:"M-l") # List
+      test.assert_screen
+      test.send_keys(:"C-n") # Switch
+      test.assert_screen
+    ensure
+      test.stop
+    end
   end
 end

--- a/spec/integration/default_key_bindings/default_key_bindings_spec.rb
+++ b/spec/integration/default_key_bindings/default_key_bindings_spec.rb
@@ -5,147 +5,161 @@ RSpec.describe 'Default key bindings', integration: true do
 
   context 'with switch filter binding' do
     it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'filter_key_bindings.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F2)
-      test.assert_screen
-      test.send_keys(:F2)
-      test.assert_screen
-      test.send_keys(:F2)
-      test.assert_screen
-      test.send_keys(:F2)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'filter_key_bindings.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F2)
+        test.assert_screen
+        test.send_keys(:F2)
+        test.assert_screen
+        test.send_keys(:F2)
+        test.assert_screen
+        test.send_keys(:F2)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with next and step bindings' do
     it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'next_step_key_bindings.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F8)
-      test.assert_screen
-      test.send_keys(:F8)
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'next_step_key_bindings.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F8)
+        test.assert_screen
+        test.send_keys(:F8)
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with step/step-out bindings' do
     it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'step_step_out_key_bindings.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-      test.send_keys(:"S-F7")
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'step_step_out_key_bindings.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+        test.send_keys(:"S-F7")
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with up/down bindings' do
     it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'up_down_key_bindings.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F7)
-      test.assert_screen
-      test.send_keys(:F6)
-      test.assert_screen
-      test.send_keys(:F6)
-      test.assert_screen
-      test.send_keys(:"S-F6")
-      test.assert_screen
-      test.send_keys(:"S-F6")
-      test.assert_screen
-      test.send_keys(:F8)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'up_down_key_bindings.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F7)
+        test.assert_screen
+        test.send_keys(:F6)
+        test.assert_screen
+        test.send_keys(:F6)
+        test.assert_screen
+        test.send_keys(:"S-F6")
+        test.assert_screen
+        test.send_keys(:"S-F6")
+        test.assert_screen
+        test.send_keys(:F8)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with continue bindings' do
     context 'with F9' do
       it 'matches expected screens' do
-        test = JardIntegrationTest.new(
-          self, work_dir,
-          'continue_key_bindings.expected',
-          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
-        )
-        test.start
-        test.assert_screen
-        test.send_keys(:F9)
-        test.assert_screen
-      ensure
-        test.stop
+        begin
+          test = JardIntegrationTest.new(
+            self, work_dir,
+            'continue_key_bindings.expected',
+            "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
+          )
+          test.start
+          test.assert_screen
+          test.send_keys(:F9)
+          test.assert_screen
+        ensure
+          test.stop
+        end
       end
     end
 
     context 'with CTRL_D' do
       it 'matches expected screens' do
-        test = JardIntegrationTest.new(
-          self, work_dir,
-          'continue_key_bindings_2.expected',
-          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
-        )
-        test.start
-        test.assert_screen
-        test.send_keys(:"C-d")
-        test.assert_screen
-      ensure
-        test.stop
+        begin
+          test = JardIntegrationTest.new(
+            self, work_dir,
+            'continue_key_bindings_2.expected',
+            "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
+          )
+          test.start
+          test.assert_screen
+          test.send_keys(:"C-d")
+          test.assert_screen
+        ensure
+          test.stop
+        end
       end
     end
   end
 
   context 'with list bindings' do
     it 'matches expected screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'list_key_bindings.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:F5)
-      test.assert_screen
-      test.send_keys(:F5)
-      test.assert_screen
-      test.send_keys(:F5)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'list_key_bindings.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:F5)
+        test.assert_screen
+        test.send_keys(:F5)
+        test.assert_screen
+        test.send_keys(:F5)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/hide_show/hide_show_screen_spec.rb
+++ b/spec/integration/hide_show/hide_show_screen_spec.rb
@@ -5,80 +5,86 @@ RSpec.describe 'Hide/show screens', integration: true do
 
   context 'when hiding/showing a screen on the top' do
     it 'strecthes the lower screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'top.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'top.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('jard hide variables', :Enter)
-      test.assert_screen
+        test.send_keys('jard hide variables', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard hide source', :Enter)
-      test.assert_screen
+        test.send_keys('jard hide source', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard show variables', :Enter)
-      test.assert_screen
+        test.send_keys('jard show variables', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard show source', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('jard show source', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when hiding/showing a screen on the bottom' do
     it 'strecthes the upper screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'bottom.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 130, height: 30
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'bottom.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 130, height: 30
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('jard hide threads', :Enter)
-      test.assert_screen
+        test.send_keys('jard hide threads', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard hide backtrace', :Enter)
-      test.assert_screen
+        test.send_keys('jard hide backtrace', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard show threads', :Enter)
-      test.assert_screen
+        test.send_keys('jard show threads', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard show backtrace', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('jard show backtrace', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when hiding/showing a screen not in the same column' do
     it 'strecthes the neighbor screens' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'not_same_column.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
-        width: 130, height: 30
-      )
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'not_same_column.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\"",
+          width: 130, height: 30
+        )
 
-      test.start
-      test.assert_screen
+        test.start
+        test.assert_screen
 
-      test.send_keys('jard hide threads', :Enter)
-      test.send_keys('jard hide backtrace', :Enter)
-      test.send_keys('jard hide source', :Enter)
+        test.send_keys('jard hide threads', :Enter)
+        test.send_keys('jard hide backtrace', :Enter)
+        test.send_keys('jard hide source', :Enter)
 
-      test.assert_screen
-      test.send_keys('jard show source', :Enter)
+        test.assert_screen
+        test.send_keys('jard show source', :Enter)
 
-      test.assert_screen
-    ensure
-      test.stop
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/interruption/interruption_spec.rb
+++ b/spec/integration/interruption/interruption_spec.rb
@@ -5,67 +5,73 @@ RSpec.describe 'Interruption test', integration: true do
 
   context 'when press Ctrl+C when repl is idle' do
     it 'does nothing' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'idle.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
-      )
-      test.start
-      test.assert_screen
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.assert_screen
-      test.send_keys('23', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'idle.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
+        )
+        test.start
+        test.assert_screen
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.assert_screen
+        test.send_keys('23', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when press Ctrl+C when repl has pending texts' do
     it 'breaks to new line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'pending.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('a = 1')
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.assert_screen
-      test.send_keys('23', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'pending.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('a = 1')
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.assert_screen
+        test.send_keys('23', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when press Ctrl+C during evaluation' do
     it 'breaks to new line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'evaluation.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('sleep 3', :Enter)
-      sleep 1
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.send_keys(:"C-c")
-      test.assert_screen
-      test.send_keys('23', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'evaluation.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 1\""
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('sleep 3', :Enter)
+        sleep 1
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.send_keys(:"C-c")
+        test.assert_screen
+        test.send_keys('23', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/multithread/multithread_spec.rb
+++ b/spec/integration/multithread/multithread_spec.rb
@@ -5,32 +5,34 @@ RSpec.describe 'Debugging multi-threads', integration: true do
 
   context 'when two threads are attaching' do
     it 'attaches one thread, and hold another thread' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'on_hold.expected',
-        'bundle exec ruby ../../examples/multithread_example.rb'
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('@index = 2', :Enter)
-      test.send_keys('a', :Enter)
-      test.send_keys('b', :Enter)
-      test.send_keys('a + b', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('a', :Enter)
-      test.send_keys('b', :Enter)
-      test.send_keys('a + b', :Enter)
-      test.assert_screen
-      test.send_keys('@index = 4', :Enter)
-      test.send_keys('continue', :Enter)
-      test.send_keys('continue', :Enter)
-      test.send_keys('continue', :Enter)
-      sleep 1
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'on_hold.expected',
+          'bundle exec ruby ../../examples/multithread_example.rb'
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('@index = 2', :Enter)
+        test.send_keys('a', :Enter)
+        test.send_keys('b', :Enter)
+        test.send_keys('a + b', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('a', :Enter)
+        test.send_keys('b', :Enter)
+        test.send_keys('a + b', :Enter)
+        test.assert_screen
+        test.send_keys('@index = 4', :Enter)
+        test.send_keys('continue', :Enter)
+        test.send_keys('continue', :Enter)
+        test.send_keys('continue', :Enter)
+        sleep 1
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/placements/placement_5.expected
+++ b/spec/integration/placements/placement_5.expected
@@ -12,7 +12,7 @@
 │  10 erb = ERB.new(view)                                                      │
 │  11 erb.filename = __FILE__                                                  │
 │  12 erb.lineno = lineno                                                      │
-│  13 erb.result_with_hash({})                                                 │
+│  13 erb.result                                                               │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -20,7 +20,7 @@
 ├──────────────────────────────────────────────────────────────────────────────┤
 │Filter (F2): Application -../../examples/top_level_example.rb   Step (F7)    »│
 └──────────────────────────────────────────────────────────────────────────────┘
-jard >>             
+jard >>
 
 
 ### END SCREEN ###
@@ -41,7 +41,7 @@ jard >>
 │  10 erb = ERB.new(view)                                                      │
 │  11 erb.filename = __FILE__                                                  │
 │  12 erb.lineno = lineno                                                      │
-│  13 erb.result_with_hash({})                                                 │
+│  13 erb.result                                                               │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -49,7 +49,7 @@ jard >>
 ├──────────────────────────────────────────────────────────────────────────────┤
 │Filter (F2): Application -../../examples/top_level_example.rb   Step (F7)    »│
 └──────────────────────────────────────────────────────────────────────────────┘
-jard >>             
+jard >>
 
 
 ### END SCREEN ###

--- a/spec/integration/placements/placement_spec.rb
+++ b/spec/integration/placements/placement_spec.rb
@@ -5,178 +5,202 @@ RSpec.describe 'Test different placement positions', integration: true do
 
   context 'when calling jard next to jard' do
     it 'stops at next line' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_1.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_1_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_1.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_1_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling print next to jard' do
     it 'stops at next line' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_2.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_2.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling as a method argument' do
     it 'stops at next line' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_3.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_3_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_3.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_3_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling as a string interpolation' do
     it 'stops at next line' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_4.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_4_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_4.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_4_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when wrongly placed inside an erb' do
     it 'ignores exluded file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_5.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_5_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_5.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_5_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when place jard in an ignored file' do
     it 'ignores exluded file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_6.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_6_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_6.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_6_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when place jard after an or' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_7.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_7_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_7.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_7_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when place jard inside a nested print' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_8.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/placement_8_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_8.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/placement_8_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling jard from a required file inside irb' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_9.expected',
-        'bundle exec irb'
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('require_relative "../../examples/top_level_2_example.rb"', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_9.expected',
+          'bundle exec irb'
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('require_relative "../../examples/top_level_2_example.rb"', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling jard from a ignored required file inside irb' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_10.expected',
-        'bundle exec irb'
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('require_relative "../../examples/top_level_example.rb"', :Enter)
-      test.send_keys('system("clear")', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_10.expected',
+          'bundle exec irb'
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('require_relative "../../examples/top_level_example.rb"', :Enter)
+        test.send_keys('system("clear")', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling jard from a method call inside irb' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_11.expected',
-        'bundle exec irb'
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('require_relative "../../examples/instance_method_example.rb"', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_11.expected',
+          'bundle exec irb'
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('require_relative "../../examples/instance_method_example.rb"', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calling jard directly inside irb' do
     it 'stops at the next file' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'placement_12.expected',
-        'bundle exec irb'
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('require "ruby_jard"', :Enter)
-      test.send_keys('def method_a', :Enter)
-      test.send_keys('  jard', :Enter)
-      test.send_keys('end', :Enter)
-      test.send_keys('method_a', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'placement_12.expected',
+          'bundle exec irb'
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('require "ruby_jard"', :Enter)
+        test.send_keys('def method_a', :Enter)
+        test.send_keys('  jard', :Enter)
+        test.send_keys('end', :Enter)
+        test.send_keys('method_a', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/scenario_1/scenario_1_spec.rb
+++ b/spec/integration/scenario_1/scenario_1_spec.rb
@@ -4,61 +4,63 @@ RSpec.describe 'Scenario 1: Debug a simple sorting algorithm' do
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/scenario_1') }
 
   it 'runs as expected' do
-    test = JardIntegrationTest.new(
-      self, work_dir,
-      'scenario_1.expected',
-      "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_1/main_example.rb",
-      width: 125, height: 30
-    )
-    test.start
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('continue', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('node.val', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('final_head', :Enter)
-    test.send_keys('final_tail', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('continue', :Enter)
-    test.send_keys('final_tail', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('up', :Enter)
-    test.send_keys('up', :Enter)
-    test.assert_screen
-    test.send_keys('down', :Enter)
-    sleep 1
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    sleep 1
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('exit', :Enter)
-  ensure
-    test.stop
+    begin
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'scenario_1.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_1/main_example.rb",
+        width: 125, height: 30
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('node.val', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('final_head', :Enter)
+      test.send_keys('final_tail', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('continue', :Enter)
+      test.send_keys('final_tail', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('up', :Enter)
+      test.send_keys('up', :Enter)
+      test.assert_screen
+      test.send_keys('down', :Enter)
+      sleep 1
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      sleep 1
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('exit', :Enter)
+    ensure
+      test.stop
+    end
   end
 end

--- a/spec/integration/scenario_2/scenario_2_spec.rb
+++ b/spec/integration/scenario_2/scenario_2_spec.rb
@@ -4,69 +4,71 @@ RSpec.describe 'Scenario 2: Debug a simple gem' do
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/scenario_2') }
 
   it 'runs as expected' do
-    test = JardIntegrationTest.new(
-      self, work_dir,
-      'scenario_2.expected',
-      "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_2/main_example.rb",
-      width: 125, height: 30
-    )
-    test.start
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('step-out', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('up', :Enter)
-    test.send_keys('array', :Enter)
-    test.send_keys('array[mid..array.length - 1]', :Enter)
-    test.assert_screen
-    test.send_keys('down', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('step-out', :Enter)
-    test.assert_screen
-    test.send_keys('next', :Enter)
-    test.send_keys('step', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('next', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('less.call(1, 3)', :Enter)
-    test.send_keys('less.call(100, 99)', :Enter)
-    test.assert_screen
-    test.send_keys('list', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('jard output', :Enter)
-    test.assert_screen
-    test.send_keys('q', :Enter)
-    test.send_keys('continue', :Enter)
-  ensure
-    test.stop
+    begin
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'scenario_2.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_2/main_example.rb",
+        width: 125, height: 30
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('step-out', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('up', :Enter)
+      test.send_keys('array', :Enter)
+      test.send_keys('array[mid..array.length - 1]', :Enter)
+      test.assert_screen
+      test.send_keys('down', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('step-out', :Enter)
+      test.assert_screen
+      test.send_keys('next', :Enter)
+      test.send_keys('step', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('next', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('less.call(1, 3)', :Enter)
+      test.send_keys('less.call(100, 99)', :Enter)
+      test.assert_screen
+      test.send_keys('list', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('jard output', :Enter)
+      test.assert_screen
+      test.send_keys('q', :Enter)
+      test.send_keys('continue', :Enter)
+    ensure
+      test.stop
+    end
   end
 end

--- a/spec/integration/scenario_3/scenario_3_spec.rb
+++ b/spec/integration/scenario_3/scenario_3_spec.rb
@@ -4,58 +4,60 @@ RSpec.describe 'Scenario 3: Turn on and off filter when debugging gem' do
   let(:work_dir) { File.join(RSPEC_ROOT, '/integration/scenario_3') }
 
   it 'runs as expected' do
-    test = JardIntegrationTest.new(
-      self, work_dir,
-      'scenario_3.expected',
-      "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_3/main_example.rb",
-      width: 125, height: 30
-    )
-    test.start
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('jard filter gems', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('jard filter application', :Enter)
-    test.send_keys('jard filter include jard_merge_sort', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('jard filter clear', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('jard filter include securerandom', :Enter)
-    test.send_keys('step', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('jard filter exclude securerandom', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('step', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('next', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('step-out', :Enter)
-    test.send_keys('jard filter source_tree', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.send_keys('step', :Enter)
-    test.assert_screen
-    test.send_keys('jard filter include ../../examples/dummy_heap.rb', :Enter)
-    test.assert_screen
-    test.send_keys('step', :Enter)
-    test.assert_screen
-  ensure
-    test.stop
+    begin
+      test = JardIntegrationTest.new(
+        self, work_dir,
+        'scenario_3.expected',
+        "bundle exec ruby #{RSPEC_ROOT}/integration/scenario_3/main_example.rb",
+        width: 125, height: 30
+      )
+      test.start
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('jard filter gems', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('jard filter application', :Enter)
+      test.send_keys('jard filter include jard_merge_sort', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('jard filter clear', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('jard filter include securerandom', :Enter)
+      test.send_keys('step', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('jard filter exclude securerandom', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('step', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('next', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('step-out', :Enter)
+      test.send_keys('jard filter source_tree', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.send_keys('step', :Enter)
+      test.assert_screen
+      test.send_keys('jard filter include ../../examples/dummy_heap.rb', :Enter)
+      test.assert_screen
+      test.send_keys('step', :Enter)
+      test.assert_screen
+    ensure
+      test.stop
+    end
   end
 end

--- a/spec/integration/screens/backtrace/backtrace_screen_spec.rb
+++ b/spec/integration/screens/backtrace/backtrace_screen_spec.rb
@@ -5,121 +5,135 @@ RSpec.describe 'Backtrace screen', integration: true do
 
   context 'when jard stops at top-level binding' do
     it 'displays top-level backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'top_level.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'top_level.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops inside an instance method' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'instance_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'instance_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops inside a class method' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'class_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/class_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'class_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/class_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops within a nested method' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'nested_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'nested_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops at the beginning of file or at the end of file' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'end_of_file.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/start_of_file_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'end_of_file.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/start_of_file_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard steps into a code evaluation' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'code_evaluation.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter everything', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step-out', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'code_evaluation.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter everything', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step-out', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when stop at the end of a method' do
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'end_of_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'end_of_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
@@ -133,105 +147,111 @@ RSpec.describe 'Backtrace screen', integration: true do
     end
 
     it 'displays correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'ruby_e.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\""
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'ruby_e.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\""
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when working with Basic Object' do
     it 'display correct backtrace inside basic object' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'basic_object.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/basic_object_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'basic_object.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/basic_object_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when explore the backtrace with filter on/off' do
     it 'display correct backtrace' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'explore_filter_on_off.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/sort_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('up', :Enter)
-      test.assert_screen
-      test.send_keys('up', :Enter)
-      test.assert_screen
-      test.send_keys('down 2', :Enter)
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'explore_filter_on_off.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/sort_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('up', :Enter)
+        test.assert_screen
+        test.send_keys('up', :Enter)
+        test.assert_screen
+        test.send_keys('down 2', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard filter gems', :Enter)
-      test.assert_screen
-      test.send_keys('up', :Enter)
-      test.send_keys('up', :Enter)
-      test.send_keys('up', :Enter)
-      test.send_keys('up', :Enter)
-      test.assert_screen
-      test.send_keys('up 4', :Enter)
-      test.assert_screen
+        test.send_keys('jard filter gems', :Enter)
+        test.assert_screen
+        test.send_keys('up', :Enter)
+        test.send_keys('up', :Enter)
+        test.send_keys('up', :Enter)
+        test.send_keys('up', :Enter)
+        test.assert_screen
+        test.send_keys('up 4', :Enter)
+        test.assert_screen
 
-      test.send_keys('frame 2', :Enter)
-      test.assert_screen
-      test.send_keys('frame 7', :Enter)
-      test.assert_screen
+        test.send_keys('frame 2', :Enter)
+        test.assert_screen
+        test.send_keys('frame 7', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard filter application', :Enter)
-      test.assert_screen
-      test.send_keys('frame 2', :Enter)
-      test.assert_screen
-      test.send_keys('down', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter gems', :Enter)
-      test.send_keys('frame 2', :Enter)
-      test.send_keys('jard filter application', :Enter)
-      test.assert_screen
-      test.send_keys('up', :Enter)
-      test.assert_screen
+        test.send_keys('jard filter application', :Enter)
+        test.assert_screen
+        test.send_keys('frame 2', :Enter)
+        test.assert_screen
+        test.send_keys('down', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter gems', :Enter)
+        test.send_keys('frame 2', :Enter)
+        test.send_keys('jard filter application', :Enter)
+        test.assert_screen
+        test.send_keys('up', :Enter)
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
+        test.send_keys('continue', :Enter)
 
-      test.send_keys('step', :Enter)
-      test.send_keys('step', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter everything', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('frame 10', :Enter)
-      test.assert_screen
-      test.send_keys('frame 7', :Enter)
-      test.assert_screen
-      test.send_keys('up', :Enter)
-      test.assert_screen
-      test.send_keys('down', :Enter)
-      test.assert_screen
+        test.send_keys('step', :Enter)
+        test.send_keys('step', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter everything', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('frame 10', :Enter)
+        test.assert_screen
+        test.send_keys('frame 7', :Enter)
+        test.assert_screen
+        test.send_keys('up', :Enter)
+        test.assert_screen
+        test.send_keys('down', :Enter)
+        test.assert_screen
 
-      test.send_keys('jard filter application', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('jard filter application', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/screens/menu/menu_screen_spec.rb
+++ b/spec/integration/screens/menu/menu_screen_spec.rb
@@ -5,86 +5,94 @@ RSpec.describe 'Menu screen', integration: true do
 
   context 'with default menu screen' do
     it 'displays default filter and keybindings' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'default_menu.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
-        width: 120, height: 5
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'default_menu.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
+          width: 120, height: 5
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with tiny window' do
     it 'prioritizes filter' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'tiny_menu.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
-        width: 50, height: 10
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter include rails', :Enter)
-      test.send_keys('jard filter exclude spec*', :Enter)
-      test.send_keys('jard filter exclude some_thing*', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'tiny_menu.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
+          width: 50, height: 10
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter include rails', :Enter)
+        test.send_keys('jard filter exclude spec*', :Enter)
+        test.send_keys('jard filter exclude some_thing*', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when switching filter modes' do
     it 'displays current filter mode and keybindings' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'switch_modes.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
-        width: 120, height: 5
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter gems', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter source_tree', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter everything', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter application', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'switch_modes.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
+          width: 120, height: 5
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter gems', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter source_tree', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter everything', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter application', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when include/exclude filters' do
     it 'displays current filter mode, filters and keybindings' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'include_exclude_filters.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
-        width: 120, height: 5
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter gems', :Enter)
-      test.send_keys('jard filter include rails', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter exclude spec*', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter include ~/library_a/abc.rb', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter include test*', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter exclude rails', :Enter)
-      test.assert_screen
-      test.send_keys('jard filter clear', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'include_exclude_filters.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb",
+          width: 120, height: 5
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter gems', :Enter)
+        test.send_keys('jard filter include rails', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter exclude spec*', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter include ~/library_a/abc.rb', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter include test*', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter exclude rails', :Enter)
+        test.assert_screen
+        test.send_keys('jard filter clear', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/screens/source/source_screen_spec.rb
+++ b/spec/integration/screens/source/source_screen_spec.rb
@@ -5,132 +5,148 @@ RSpec.describe 'Source screen', integration: true do
 
   context 'when jard stops at top-level binding' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'top_level_example.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'top_level_example.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops inside an instance method' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'instance_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'instance_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops within a nested method' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'nested_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'nested_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops at the beginning of file or at the end of file' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'end_of_file.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/start_of_file_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'end_of_file.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/start_of_file_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard steps into a code evaluation' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'code_evaluation.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter everything', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step-out', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'code_evaluation.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter everything', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step-out', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when stop at the end of a method' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'end_of_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'end_of_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when use jard with ruby -e' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'ruby_e.expected',
-        "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\""
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'ruby_e.expected',
+          "bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\""
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jumping into an ERB file' do
     it 'displays correct line' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'erb_file.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'erb_file.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/screens/threads/threads_screen_spec.rb
+++ b/spec/integration/screens/threads/threads_screen_spec.rb
@@ -5,88 +5,98 @@ RSpec.describe 'Threads screen', integration: true do
 
   context 'when jard stops at top-level binding' do
     it 'displays current threads' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'top_level.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'top_level.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when the program includes other untitled threads' do
     it 'display all untitled threads' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'threads_untitled.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/threads_untitled.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'threads_untitled.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/threads_untitled.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when threads have title' do
     it 'display all titled threads, sorted by name, then path' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'threads_title.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/threads_title.rb"
-      )
-      test.start
-      sleep 0.5
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'threads_title.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/threads_title.rb"
+        )
+        test.start
+        sleep 0.5
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      sleep 0.5
-      test.assert_screen
+        test.send_keys('continue', :Enter)
+        sleep 0.5
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      sleep 0.5
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        sleep 0.5
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when there are dead threads' do
     it 'excludes all dead threads' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'threads_dead.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/threads_dead.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'threads_dead.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/threads_dead.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      sleep 0.5
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        sleep 0.5
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when threads are spawn in background' do
     it 'captures all new threads' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'threads_spawn.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/threads_spawn.rb"
-      )
-      test.start
-      test.assert_screen
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'threads_spawn.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/threads_spawn.rb"
+        )
+        test.start
+        test.assert_screen
 
-      test.send_keys('continue', :Enter)
-      sleep 0.5
-      test.assert_screen
-    ensure
-      test.stop
+        test.send_keys('continue', :Enter)
+        sleep 0.5
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/screens/variables/variables_screen_spec.rb
+++ b/spec/integration/screens/variables/variables_screen_spec.rb
@@ -5,231 +5,257 @@ RSpec.describe 'Variable screen', integration: true do
 
   context 'when jard stops at top-level binding' do
     it 'captures all variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'top_level.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'top_level.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/top_level_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops at an instance method' do
     it 'captures all variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'instance_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'instance_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops inside a class method' do
     it 'captures all variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'class_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/class_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'class_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/class_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops inside a nested loop' do
     it 'captures all variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'nested_loop.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'nested_loop.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/nested_loop_example.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'with jard jumping between methods' do
     it 'captures all variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'jump.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'jump.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/instance_method_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard steps into a code evaluation' do
     it 'display relevant variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'code_evaluation.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('jard filter everything', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step-out', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'code_evaluation.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/evaluation_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('jard filter everything', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step-out', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jard stops at the end of a method' do
     it 'display relevant variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'end_of_method.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'end_of_method.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/end_of_method_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when use jard with ruby -e' do
     it 'display relevant variables' do
-      code = <<~CODE
-        bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\nb = a + 1\"
-      CODE
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'ruby_e.expected',
-        code
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('next', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        code = <<~CODE
+          bundle exec ruby -e \"require 'ruby_jard'\njard\na = 100 + 300\nb = a + 1\"
+        CODE
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'ruby_e.expected',
+          code
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('next', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when jumping into an ERB file' do
     it 'display relevant variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'erb_file.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb"
-      )
-      test.start
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'erb_file.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/erb_evaluation.rb"
+        )
+        test.start
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when constants come from different sources' do
     it 'display relevant constant and global variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'complicated_constant.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_constant_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'complicated_constant.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_constant_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when instance variables come from different sources' do
     it 'display relevant instance variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'complicated_instance.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_instance_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'complicated_instance.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/complicated_instance_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when working with Basic Object' do
     it 'display relevant instance variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'basic_object.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/basic_object_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.assert_screen
-      test.send_keys('step', :Enter)
-      test.send_keys('step', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'basic_object.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/basic_object_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.assert_screen
+        test.send_keys('step', :Enter)
+        test.send_keys('step', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when working with circular reference object' do
     it 'display relevant instance variables' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'circular_reference.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/circular_reference_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'circular_reference.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/circular_reference_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/skip/skip_spec.rb
+++ b/spec/integration/skip/skip_spec.rb
@@ -5,69 +5,75 @@ RSpec.describe 'Test skip' do
 
   context 'when place jard in a nested loop' do
     it 'runs as expected' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'nested_loop.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/skip_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.send_keys('continue', :Enter)
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('skip', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('skip 2', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'nested_loop.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/skip_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.send_keys('continue', :Enter)
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('skip', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('skip 2', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when place jard in a nested method calls' do
     it 'runs as expected' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'nested_method_call.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/skip_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('skip', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('skip 2', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'nested_method_call.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/skip_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('skip', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('skip 2', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when calls skip --all' do
     it 'runs as expected' do
-      test = JardIntegrationTest.new(
-        self, work_dir,
-        'skip_all.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/skip_2_example.rb"
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('skip --all', :Enter)
-      test.assert_screen_not_include('skip_2_example')
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir,
+          'skip_all.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/skip_2_example.rb"
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('skip --all', :Enter)
+        test.assert_screen_not_include('skip_2_example')
+      ensure
+        test.stop
+      end
     end
   end
 end

--- a/spec/integration/standard_streams/standard_streams_spec.rb
+++ b/spec/integration/standard_streams/standard_streams_spec.rb
@@ -9,143 +9,155 @@ RSpec.describe 'Test standard_streams', integration: true do
 
   context 'when nothing are redirected' do
     it 'works normally' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'normal.expected',
-        "bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb",
-        width: 121, height: 40
-      )
-      test.start
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.send_keys('Quang-Minh', :Enter)
-      test.send_keys('17', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'normal.expected',
+          "bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb",
+          width: 121, height: 40
+        )
+        test.start
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.send_keys('Quang-Minh', :Enter)
+        test.send_keys('17', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when pipe the stdin' do
     it 'works normally' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_stdin.expected', shell,
-        width: 121, height: 40
-      )
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'pipe_stdin.expected', shell,
+          width: 121, height: 40
+        )
 
-      test.start
-      test.send_keys("echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb", :Enter)
-      sleep 1
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.start
+        test.send_keys("echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb", :Enter)
+        sleep 1
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when pipe the stdout' do
     it 'works normally' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_stdout.expected', shell,
-        width: 121, height: 40
-      )
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'pipe_stdout.expected', shell,
+          width: 121, height: 40
+        )
 
-      test.start
-      test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null", :Enter)
-      sleep 1
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.send_keys('Quang-Minh', :Enter)
-      test.send_keys('17', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.start
+        test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null", :Enter)
+        sleep 1
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.send_keys('Quang-Minh', :Enter)
+        test.send_keys('17', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when pipe both stdin and stdout' do
     it 'works normally' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'pipe_both_stdin_stdout.expected', shell,
-        width: 121, height: 40
-      )
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'pipe_both_stdin_stdout.expected', shell,
+          width: 121, height: 40
+        )
 
-      test.start
-      test.send_keys(
-        "echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null",
-        :Enter
-      )
-      sleep 1
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.start
+        test.send_keys(
+          "echo \"Not Minh\n19\n\" | bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb | tail -f /dev/null",
+          :Enter
+        )
+        sleep 1
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   context 'when redirect stdout' do
     it 'works normally' do
-      test = JardIntegrationTest.new(
-        self, work_dir, 'redirect_stdout.expected', shell,
-        width: 121, height: 40
-      )
+      begin
+        test = JardIntegrationTest.new(
+          self, work_dir, 'redirect_stdout.expected', shell,
+          width: 121, height: 40
+        )
 
-      test.start
-      test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb > /dev/null", :Enter)
-      sleep 1
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.send_keys('Quang-Minh', :Enter)
-      test.send_keys('17', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('continue', :Enter)
-      test.assert_screen
-      test.send_keys('jard output', :Enter)
-      test.assert_screen
-    ensure
-      test.stop
+        test.start
+        test.send_keys("bundle exec ruby #{RSPEC_ROOT}/examples/cli.rb > /dev/null", :Enter)
+        sleep 1
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.send_keys('Quang-Minh', :Enter)
+        test.send_keys('17', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('continue', :Enter)
+        test.assert_screen
+        test.send_keys('jard output', :Enter)
+        test.assert_screen
+      ensure
+        test.stop
+      end
     end
   end
 
   if ENV['CI'].nil? || ENV['CI_PLATFORM'] != 'macos'
     context 'when a process has controlling terminal detached' do
       it 'refused to attach' do
-        test = JardIntegrationTest.new(
-          self, work_dir, 'detached.expected',
-          "bundle exec ruby #{RSPEC_ROOT}/examples/detach_example.rb",
-          width: 121, height: 40
-        )
-        test.start
-        test.assert_screen
-      ensure
-        test.stop
+        begin
+          test = JardIntegrationTest.new(
+            self, work_dir, 'detached.expected',
+            "bundle exec ruby #{RSPEC_ROOT}/examples/detach_example.rb",
+            width: 121, height: 40
+          )
+          test.start
+          test.assert_screen
+        ensure
+          test.stop
+        end
       end
     end
   end

--- a/spec/ruby_jard/config_spec.rb
+++ b/spec/ruby_jard/config_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe RubyJard::Config do
   subject(:config) { described_class.new }
 
+  before do
+    unless Object.const_defined?(:FrozenError)
+      stub_const('FrozenError', RuntimeError)
+    end
+  end
+
   it 'initializes default configurations' do
     expect(config.filter_version).to eq(0)
     expect(config.filter).to eq(:application)
@@ -19,13 +25,13 @@ RSpec.describe RubyJard::Config do
 
   it 'freezes nested data structure' do
     expect do
-      config.filter_included.append(123)
+      config.filter_included.push(123)
     end.to raise_error(FrozenError)
     expect do
-      config.filter_excluded.append(123)
+      config.filter_excluded.push(123)
     end.to raise_error(FrozenError)
     expect do
-      config.enabled_screens.append(123)
+      config.enabled_screens.push(123)
     end.to raise_error(FrozenError)
   end
 
@@ -51,7 +57,7 @@ RSpec.describe RubyJard::Config do
     it 'freezes filter_included afterward' do
       config.filter_included = ['rails']
       expect do
-        config.filter_included.append(123)
+        config.filter_included.push(123)
       end.to raise_error(FrozenError)
     end
   end
@@ -68,7 +74,7 @@ RSpec.describe RubyJard::Config do
     it 'freezes filter_excluded afterward' do
       config.filter_excluded = ['rails']
       expect do
-        config.filter_excluded.append(123)
+        config.filter_excluded.push(123)
       end.to raise_error(FrozenError)
     end
   end
@@ -81,7 +87,7 @@ RSpec.describe RubyJard::Config do
     it 'freezes filter_excluded afterward' do
       config.enabled_screens = ['source']
       expect do
-        config.enabled_screens.append(123)
+        config.enabled_screens.push(123)
       end.to raise_error(FrozenError)
     end
   end


### PR DESCRIPTION
Resolve #81 

This PR mostly fix some syntax differences between 2.4 and 2.5. Some notable changes:
* Use a fake readline library to test for compability, because reline do not support 2.4
* Classify site_ruby as stdlib (This is because the standard ruby 2.4 installation put rubygems under siteruby instead of stdlib). Relevant spec: spec/ruby_jard/path_classifier_spec.rb:94